### PR TITLE
[codex] improve encode performance and cluster guards

### DIFF
--- a/cluster/http_agent.go
+++ b/cluster/http_agent.go
@@ -32,6 +32,7 @@ type httpAgent struct {
 	messageIDMapToRequest map[uint64]*fastHttpContextObserve
 	responseChan          chan []byte
 	lastMid               uint64
+	closed                bool
 	mu                    sync.Mutex
 }
 
@@ -57,9 +58,18 @@ func NewHTTPAgent(
 	return a
 }
 
+func (h *httpAgent) isClosed() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.closed
+}
+
 func (h *httpAgent) AttackHttpRequestCtx(mid uint64, httpCtx *fasthttp.RequestCtx) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed || h.messageIDMapToRequest == nil {
+		return
+	}
 	h.messageIDMapToRequest[mid] = &fastHttpContextObserve{
 		context:       httpCtx,
 		observeStatus: HttpObserveWaiting,
@@ -69,6 +79,9 @@ func (h *httpAgent) AttackHttpRequestCtx(mid uint64, httpCtx *fasthttp.RequestCt
 func (h *httpAgent) RemoveHttpRequestCtx(mid uint64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.messageIDMapToRequest == nil {
+		return
+	}
 	if _, exists := h.messageIDMapToRequest[mid]; exists {
 		delete(h.messageIDMapToRequest, mid)
 	}
@@ -78,6 +91,9 @@ func (h *httpAgent) GetFastHttpContextObserve(mid uint64) *fastHttpContextObserv
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed || h.messageIDMapToRequest == nil {
+		return nil
+	}
 	if ctxObserve, exists := h.messageIDMapToRequest[mid]; exists {
 		return ctxObserve
 	}
@@ -85,17 +101,49 @@ func (h *httpAgent) GetFastHttpContextObserve(mid uint64) *fastHttpContextObserv
 }
 
 func (h *httpAgent) AttachResponseChan(responseChan chan []byte) {
-	h.session.NetworkEntity().(*httpAgent).responseChan = responseChan
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed || h.session == nil {
+		return
+	}
 	h.responseChan = responseChan
+	if agent, ok := h.session.NetworkEntity().(*httpAgent); ok {
+		if agent == h {
+			return
+		}
+		agent.mu.Lock()
+		agent.responseChan = responseChan
+		agent.mu.Unlock()
+	}
 }
 
 func (h *httpAgent) DeAttachResponseChan() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	h.responseChan = nil
-	h.session.NetworkEntity().(*httpAgent).responseChan = nil
+	if h.session != nil {
+		if agent, ok := h.session.NetworkEntity().(*httpAgent); ok {
+			if agent == h {
+				return
+			}
+			agent.mu.Lock()
+			agent.responseChan = nil
+			agent.mu.Unlock()
+		}
+	}
 }
 
 // Close implements session.NetworkEntity.
 func (h *httpAgent) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil
+	}
+	h.closed = true
 	h.httpCtx = nil
 	h.rpcHandler = nil
 	h.session = nil
@@ -117,6 +165,10 @@ func (h *httpAgent) OriginalSid() int64 {
 
 // Push implements session.NetworkEntity.
 func (h *httpAgent) Push(route string, v interface{}) error {
+	if h.isClosed() {
+		return ErrBrokenPipe
+	}
+
 	var body interface{}
 
 	// Check if v is already JSON
@@ -147,6 +199,12 @@ func (h *httpAgent) Push(route string, v interface{}) error {
 	}
 	log.Infof("[HTTP Agent] Push event: %s", data)
 
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed || h.sseChan == nil {
+		return ErrBrokenPipe
+	}
+
 	// Use a select statement with a default case to avoid blocking
 	select {
 	case h.sseChan <- data:
@@ -161,6 +219,10 @@ func (h *httpAgent) Push(route string, v interface{}) error {
 
 // RPC implements session.NetworkEntity.
 func (h *httpAgent) RPC(route string, v interface{}) error {
+	if h.isClosed() {
+		return ErrBrokenPipe
+	}
+
 	data, err := message.Serialize(v)
 	if err != nil {
 		return err
@@ -171,13 +233,29 @@ func (h *httpAgent) RPC(route string, v interface{}) error {
 		Data:  data,
 	}
 	log.Infof("[HTTP Agent] RPC event: %s", data)
-	h.rpcHandler(h.session, msg, true)
+
+	h.mu.Lock()
+	closed := h.closed
+	handler := h.rpcHandler
+	sess := h.session
+	h.mu.Unlock()
+	if closed || handler == nil || sess == nil {
+		return ErrBrokenPipe
+	}
+	handler(sess, msg, true)
 	return nil
 }
 
 // RemoteAddr implements session.NetworkEntity.
 func (h *httpAgent) RemoteAddr() net.Addr {
-	return h.httpCtx.RemoteAddr()
+	h.mu.Lock()
+	closed := h.closed
+	ctx := h.httpCtx
+	h.mu.Unlock()
+	if closed || ctx == nil {
+		return nil
+	}
+	return ctx.RemoteAddr()
 }
 
 // Response implements session.NetworkEntity.
@@ -187,14 +265,21 @@ func (h *httpAgent) Response(v interface{}) error {
 
 // ResponseMid implements session.NetworkEntity.
 func (h *httpAgent) ResponseMid(mid uint64, v interface{}) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	log.Infof("[HTTP Agent] ResponseMid: %v", mid)
+	if h.isClosed() {
+		return ErrBrokenPipe
+	}
+
 	data, err := message.Serialize(v)
 	if err != nil {
 		log.Errorf("[HTTP Agent] Failed to serialize response: %v error: %v", v, err)
 		return err
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed || h.messageIDMapToRequest == nil {
+		return ErrBrokenPipe
 	}
 
 	ctx, exists := h.messageIDMapToRequest[mid]
@@ -202,13 +287,18 @@ func (h *httpAgent) ResponseMid(mid uint64, v interface{}) error {
 		log.Infof("[HTTP Agent] No context found for messageID: %d, response might have timed out", mid)
 		return nil
 	}
+	if ctx == nil || ctx.context == nil {
+		return ErrBrokenPipe
+	}
 
-	log.Infof("ss ptr after insert %v", h.session.ID())
+	if h.session != nil {
+		log.Infof("ss ptr after insert %v", h.session.ID())
+	}
 	ctx.context.SetContentType("application/json")
 	ctx.context.SetBody(data)
 	ctx.context.SetStatusCode(fasthttp.StatusOK)
 
-	h.messageIDMapToRequest[mid].observeStatus = HttpObserveSuccess
+	ctx.observeStatus = HttpObserveSuccess
 
 	return nil
 }

--- a/cluster/http_agent_internal_test.go
+++ b/cluster/http_agent_internal_test.go
@@ -1,0 +1,142 @@
+package cluster
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/lonng/nano/internal/message"
+	"github.com/lonng/nano/session"
+	"github.com/valyala/fasthttp"
+)
+
+func newHTTPAgentForTest() *httpAgent {
+	var req fasthttp.Request
+	var ctx fasthttp.RequestCtx
+	req.SetRequestURI("/api")
+	ctx.Init(&req, &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}, nil)
+
+	return NewHTTPAgent(
+		123,
+		nil,
+		make(chan []byte, 16),
+		func(_ *session.Session, _ *message.Message, _ bool) {},
+		&ctx,
+	)
+}
+
+func requireNoPanic(t *testing.T, fn func() error) error {
+	t.Helper()
+	var err error
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+	err = fn()
+	return err
+}
+
+func TestHTTPAgentMethodsReturnErrBrokenPipeAfterClose(t *testing.T) {
+	agent := newHTTPAgentForTest()
+	if err := agent.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.Close(); err != nil {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "RPC",
+			call: func() error { return agent.RPC("Service.Method", nil) },
+		},
+		{
+			name: "Push",
+			call: func() error { return agent.Push("Service.Event", []byte(`{"ok":true}`)) },
+		},
+		{
+			name: "Response",
+			call: func() error { return agent.Response(nil) },
+		},
+		{
+			name: "ResponseMid",
+			call: func() error { return agent.ResponseMid(1, nil) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := requireNoPanic(t, tt.call); err != ErrBrokenPipe {
+				t.Fatalf("error = %v, want %v", err, ErrBrokenPipe)
+			}
+		})
+	}
+}
+
+func TestHTTPAgentConcurrentCloseAndMethodsRaceFree(t *testing.T) {
+	agent := newHTTPAgentForTest()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				_ = requireNoPanic(t, func() error { return agent.RPC("Service.Method", []byte("payload")) })
+				_ = requireNoPanic(t, func() error { return agent.Push("Service.Event", []byte(`{"ok":true}`)) })
+				_ = requireNoPanic(t, func() error { return agent.ResponseMid(uint64(j+1), []byte(`{"ok":true}`)) })
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			_ = agent.Close()
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestHTTPAgentOpenPathStillWorks(t *testing.T) {
+	var (
+		called bool
+		got    *message.Message
+	)
+	agent := newHTTPAgentForTest()
+	agent.rpcHandler = func(_ *session.Session, msg *message.Message, noCopy bool) {
+		called = true
+		got = msg
+		if !noCopy {
+			t.Fatal("RPC noCopy = false, want true")
+		}
+	}
+
+	if err := agent.RPC("Service.Method", []byte("payload")); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("RPC handler was not called")
+	}
+	if got == nil || got.Route != "Service.Method" || got.Type != message.Notify || string(got.Data) != "payload" {
+		t.Fatalf("unexpected RPC message: %+v", got)
+	}
+
+	if err := agent.Push("Service.Event", []byte(`{"ok":true}`)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case data := <-agent.sseChan:
+		if string(data) != `{"body":{"ok":true},"route":"Service.Event"}` {
+			t.Fatalf("unexpected SSE data: %s", data)
+		}
+	default:
+		t.Fatal("Push did not enqueue SSE data")
+	}
+}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -23,9 +23,12 @@ package cluster
 import (
 	"bufio"
 	"context"
+	cryptorand "crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -54,6 +57,12 @@ var (
 
 	// ErrLimitConnection the connection of the ip is reach the limit
 	ErrLimitConnection = errors.New("reach the limit of connection")
+)
+
+const (
+	defaultCORSAllowOrigin  = "*"
+	defaultCORSAllowMethods = "POST, GET, OPTIONS, PUT, DELETE"
+	defaultCORSAllowHeaders = "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-SSE-SessionID"
 )
 
 // Options contains some configurations for current node
@@ -156,13 +165,9 @@ func (n *Node) listenAndServe() {
 	// Start the fasthttp server
 	server := &fasthttp.Server{
 		Handler: func(ctx *fasthttp.RequestCtx) {
-			// Set CORS headers to accept all
-			ctx.Response.Header.Set("Access-Control-Allow-Origin", "*")
-			ctx.Response.Header.Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-			ctx.Response.Header.Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-SSE-SessionID")
+			applyDefaultCORSHeaders(ctx)
 
-			// Handle preflight requests
-			if string(ctx.Method()) == "OPTIONS" {
+			if isPreflightRequest(ctx) {
 				ctx.SetStatusCode(fasthttp.StatusOK)
 				return
 			}
@@ -175,6 +180,16 @@ func (n *Node) listenAndServe() {
 	if err := server.ListenAndServe(n.ClientAddr); err != nil {
 		log.Println(fmt.Sprintf("Error starting fasthttp server: %v", err))
 	}
+}
+
+func applyDefaultCORSHeaders(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.Set("Access-Control-Allow-Origin", defaultCORSAllowOrigin)
+	ctx.Response.Header.Set("Access-Control-Allow-Methods", defaultCORSAllowMethods)
+	ctx.Response.Header.Set("Access-Control-Allow-Headers", defaultCORSAllowHeaders)
+}
+
+func isPreflightRequest(ctx *fasthttp.RequestCtx) bool {
+	return string(ctx.Method()) == fasthttp.MethodOptions
 }
 
 // handleFastHTTP is the request handler for fasthttp
@@ -380,34 +395,12 @@ func (n *Node) handleSSE(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 	log.Infof("SSE connection established")
 
-	// Check if session ID cookie exists
-	var sessionID string
-	cookie := ctx.Request.Header.Cookie("sse_sessionID")
-	if len(cookie) == 0 {
-		// Try to get sessionID from "X-SSE-SessionID" header
-		sessionIDHeader := ctx.Request.Header.Peek("X-SSE-SessionID")
-		sessionID = string(sessionIDHeader)
-		// if sessionIDHeader is not exist, get from search params
-		if sessionID == "" {
-			sessionID = string(ctx.QueryArgs().Peek("sse_sessionID"))
-		}
-	} else {
-		sessionID = string(cookie)
-	}
-
+	sessionID := sseSessionIDFromRequest(ctx)
 	if len(sessionID) == 0 {
 		// Generate a new session ID if cookie doesn't exist
 		sessionID = generateSessionID()
 		// Set the session ID cookie for the client
-		c := fasthttp.AcquireCookie()
-		c.SetKey("sse_sessionID")
-		c.SetValue(sessionID)
-		c.SetPath("/")
-		c.SetMaxAge(3600) // 1 hour
-		c.SetHTTPOnly(true)
-		c.SetSecure(true)
-		ctx.Response.Header.SetCookie(c)
-		fasthttp.ReleaseCookie(c)
+		setSSESessionCookie(ctx, sessionID)
 	}
 
 	// Create a channel for sending events
@@ -472,6 +465,32 @@ func (n *Node) handleSSE(ctx *fasthttp.RequestCtx) {
 
 }
 
+func sseSessionIDFromRequest(ctx *fasthttp.RequestCtx) string {
+	cookie := ctx.Request.Header.Cookie("sse_sessionID")
+	if len(cookie) > 0 {
+		return string(cookie)
+	}
+
+	sessionIDHeader := ctx.Request.Header.Peek("X-SSE-SessionID")
+	if len(sessionIDHeader) > 0 {
+		return string(sessionIDHeader)
+	}
+
+	return string(ctx.QueryArgs().Peek("sse_sessionID"))
+}
+
+func setSSESessionCookie(ctx *fasthttp.RequestCtx, sessionID string) {
+	c := fasthttp.AcquireCookie()
+	c.SetKey("sse_sessionID")
+	c.SetValue(sessionID)
+	c.SetPath("/")
+	c.SetMaxAge(3600) // 1 hour
+	c.SetHTTPOnly(true)
+	c.SetSecure(true)
+	ctx.Response.Header.SetCookie(c)
+	fasthttp.ReleaseCookie(c)
+}
+
 func (n *Node) registerSSEClient(sessionID string, eventChan chan []byte) {
 	log.Infof("Register SSE client: %s", sessionID)
 	n.mu.Lock()
@@ -495,7 +514,11 @@ func (n *Node) unregisterSSEClient(sessionID string) {
 }
 
 func generateSessionID() string {
-	return fmt.Sprintf("%d", time.Now().UnixNano())
+	n, err := cryptorand.Int(cryptorand.Reader, big.NewInt(math.MaxInt64-1))
+	if err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("%d", n.Int64()+1)
 }
 
 // listenAndServeWS handles WebSocket connections using fasthttp
@@ -775,10 +798,10 @@ func (n *Node) decreaseConnection(ipAddress string) {
 	metrics.ConnectionsPerIP.WithLabelValues(ipAddress).Dec()
 
 	if n.LimitConnectPerIp > 0 {
+		n.mu.Lock()
+		defer n.mu.Unlock()
 		if _, ok := n.connectionCount[ipAddress]; ok {
 			if n.connectionCount[ipAddress] > 0 {
-				n.mu.Lock()
-				defer n.mu.Unlock()
 				n.connectionCount[ipAddress]--
 				log.Println(fmt.Sprintf("DecreaseConnection of ip %s the connect remain  %v", ipAddress, n.connectionCount[ipAddress]))
 

--- a/cluster/node_internal_test.go
+++ b/cluster/node_internal_test.go
@@ -1,0 +1,173 @@
+package cluster
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lonng/nano/internal/env"
+	"github.com/valyala/fasthttp"
+)
+
+func TestDecreaseConnectionConcurrentAccess(t *testing.T) {
+	n := &Node{
+		Options: Options{
+			LimitConnectPerIp: 1000000,
+		},
+		connectionCount: map[string]uint{},
+	}
+
+	const (
+		workers    = 8
+		iterations = 50
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if err := n.increaseConnection("127.0.0.1"); err != nil {
+					t.Errorf("increaseConnection returned error: %v", err)
+					return
+				}
+				n.decreaseConnection("127.0.0.1")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := n.connectionCount["127.0.0.1"]; got != 0 {
+		t.Fatalf("connection count = %d, want 0", got)
+	}
+}
+
+func TestGenerateSessionIDIsNumericAndNotTimestamp(t *testing.T) {
+	const count = 64
+	ids := make(map[string]struct{}, count)
+
+	for i := 0; i < count; i++ {
+		before := time.Now().UnixNano()
+		id := generateSessionID()
+		after := time.Now().UnixNano()
+		if _, err := strconv.ParseInt(id, 10, 64); err != nil {
+			t.Fatalf("session ID %q is not numeric int64: %v", id, err)
+		}
+		idValue, err := strconv.ParseInt(id, 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if idValue >= before && idValue <= after {
+			t.Fatalf("session ID %q exposes current UnixNano timestamp", id)
+		}
+		if _, exists := ids[id]; exists {
+			t.Fatalf("duplicate session ID generated: %s", id)
+		}
+		ids[id] = struct{}{}
+	}
+}
+
+func TestDefaultCORSHeadersAndPreflightBehavior(t *testing.T) {
+	var req fasthttp.Request
+	var ctx fasthttp.RequestCtx
+	req.Header.SetMethod(fasthttp.MethodOptions)
+	req.SetRequestURI("/api")
+	ctx.Init(&req, nil, nil)
+
+	applyDefaultCORSHeaders(&ctx)
+	if isPreflightRequest(&ctx) {
+		ctx.SetStatusCode(fasthttp.StatusOK)
+	}
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusOK {
+		t.Fatalf("status = %d, want %d", got, fasthttp.StatusOK)
+	}
+	if got := string(ctx.Response.Header.Peek("Access-Control-Allow-Origin")); got != "*" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want *", got)
+	}
+	if got := string(ctx.Response.Header.Peek("Access-Control-Allow-Headers")); got != "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-SSE-SessionID" {
+		t.Fatalf("Access-Control-Allow-Headers = %q", got)
+	}
+}
+
+func TestSSESessionIDFromRequestAcceptsCurrentSources(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(req *fasthttp.Request)
+	}{
+		{
+			name: "header",
+			setup: func(req *fasthttp.Request) {
+				req.Header.Set("X-SSE-SessionID", "123")
+			},
+		},
+		{
+			name: "query",
+			setup: func(req *fasthttp.Request) {
+				req.SetRequestURI("/sse?sse_sessionID=123")
+			},
+		},
+		{
+			name: "cookie",
+			setup: func(req *fasthttp.Request) {
+				req.Header.SetCookie("sse_sessionID", "123")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req fasthttp.Request
+			var ctx fasthttp.RequestCtx
+			req.Header.SetMethod(fasthttp.MethodGet)
+			req.SetRequestURI("/sse")
+			tt.setup(&req)
+			ctx.Init(&req, nil, nil)
+
+			if got := sseSessionIDFromRequest(&ctx); got != "123" {
+				t.Fatalf("session source %s = %q, want 123", tt.name, got)
+			}
+		})
+	}
+}
+
+func TestSetSSESessionCookieKeepsNumericCookieBehavior(t *testing.T) {
+	var req fasthttp.Request
+	var ctx fasthttp.RequestCtx
+	req.Header.SetMethod(fasthttp.MethodGet)
+	req.SetRequestURI("/sse")
+	ctx.Init(&req, nil, nil)
+
+	setSSESessionCookie(&ctx, generateSessionID())
+
+	cookie := string(ctx.Response.Header.PeekCookie("sse_sessionID"))
+	sessionID := strings.TrimPrefix(strings.SplitN(cookie, ";", 2)[0], "sse_sessionID=")
+	if sessionID == "" {
+		t.Fatal("sse_sessionID cookie was not set")
+	}
+	if _, err := strconv.ParseInt(sessionID, 10, 64); err != nil {
+		t.Fatalf("sse_sessionID cookie %q is not numeric int64: %v", sessionID, err)
+	}
+	if !strings.Contains(cookie, "HttpOnly") {
+		t.Fatalf("sse_sessionID cookie missing HttpOnly: %q", cookie)
+	}
+	if !strings.Contains(cookie, "secure") {
+		t.Fatalf("sse_sessionID cookie missing secure flag: %q", cookie)
+	}
+}
+
+func TestDefaultCheckOriginAllowsWebSocketOrigin(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/nano", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Origin", "http://evil.example")
+
+	if !env.CheckOrigin(req) {
+		t.Fatal("default CheckOrigin rejected origin; want current open default")
+	}
+}

--- a/examples/cluster/main.go
+++ b/examples/cluster/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"github.com/lonng/nano"
 	"github.com/lonng/nano/cluster"
@@ -149,7 +150,7 @@ func runGate(args *cli.Context) error {
 
 	pip.Inbound().PushBack(func(s *session.Session, msg *pipeline.Message) error {
 		runTimes++
-		log.Println("Inbound", runTimes, string(s.UID()))
+		log.Println("Inbound", runTimes, strconv.FormatInt(s.UID(), 10))
 		if runTimes < rand.Intn(3)+1 {
 			log.Println("Closing session due to random check")
 			// s.Close()

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -98,3 +98,56 @@ func BenchmarkDecoder_Decode(b *testing.B) {
 		}
 	}
 }
+
+func TestEncodeAllocationsStayLow(t *testing.T) {
+	data := []byte("hello world")
+	var encoded []byte
+	var err error
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		encoded, err = Encode(Data, data)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allocs > 1 {
+		t.Fatalf("Encode allocations = %.1f, want <= 1", allocs)
+	}
+
+	want := []byte{byte(Data), 0x00, 0x00, byte(len(data))}
+	want = append(want, data...)
+	if !reflect.DeepEqual(want, encoded) {
+		t.Fatalf("encoded packet changed: want %v, got %v", want, encoded)
+	}
+}
+
+func TestDecodeMalformedPacketsReturnExpectedErrors(t *testing.T) {
+	t.Run("fragmented header waits for more data", func(t *testing.T) {
+		d := NewDecoder()
+		packets, err := d.Decode([]byte{byte(Data), 0x00})
+		if err != nil {
+			t.Fatalf("Decode error = %v, want nil", err)
+		}
+		if len(packets) != 0 {
+			t.Fatalf("Decode packets = %d, want 0", len(packets))
+		}
+	})
+
+	t.Run("wrong packet type", func(t *testing.T) {
+		d := NewDecoder()
+		_, err := d.Decode([]byte{0x00, 0x00, 0x00, 0x00})
+		if err != ErrWrongPacketType {
+			t.Fatalf("Decode error = %v, want %v", err, ErrWrongPacketType)
+		}
+	})
+
+	t.Run("oversized packet", func(t *testing.T) {
+		d := NewDecoder()
+		size := MaxPacketSize + 1
+		header := []byte{byte(Data), byte((size >> 16) & 0xff), byte((size >> 8) & 0xff), byte(size & 0xff)}
+		_, err := d.Decode(header)
+		if err != ErrPacketSizeExcced {
+			t.Fatalf("Decode error = %v, want %v", err, ErrPacketSizeExcced)
+		}
+	})
+}

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -104,6 +104,29 @@ func invalidType(t Type) bool {
 
 }
 
+func messageIDSize(id uint64) int {
+	size := 1
+	for id >>= 7; id != 0; id >>= 7 {
+		size++
+	}
+	return size
+}
+
+func encodedSize(m *Message, compressed bool) int {
+	size := 1 + len(m.Data)
+	if m.Type == Request || m.Type == Response {
+		size += messageIDSize(m.ID)
+	}
+	if routable(m.Type) {
+		if compressed {
+			size += 2
+		} else {
+			size += 1 + len(m.Route)
+		}
+	}
+	return size
+}
+
 // Encode marshals message to binary format. Different message types is corresponding to
 // different message header, message types is identified by 2-4 bit of flag field. The
 // relationship between message types and message header is presented as follows:
@@ -122,13 +145,14 @@ func Encode(m *Message) ([]byte, error) {
 		return nil, ErrWrongMessageType
 	}
 
-	buf := make([]byte, 0)
 	flag := byte(m.Type) << 1
 
 	code, compressed := routes[m.Route]
 	if compressed {
 		flag |= msgRouteCompressMask
 	}
+
+	buf := make([]byte, 0, encodedSize(m, compressed))
 	buf = append(buf, flag)
 
 	if m.Type == Request || m.Type == Response {
@@ -152,7 +176,7 @@ func Encode(m *Message) ([]byte, error) {
 			buf = append(buf, byte(code&0xFF))
 		} else {
 			buf = append(buf, byte(len(m.Route)))
-			buf = append(buf, []byte(m.Route)...)
+			buf = append(buf, m.Route...)
 		}
 	}
 
@@ -198,6 +222,9 @@ func Decode(data []byte) (*Message, error) {
 	if routable(m.Type) {
 		if flag&msgRouteCompressMask == 1 {
 			m.compressed = true
+			if offset+2 > len(data) {
+				return nil, ErrWrongMessage
+			}
 			code := binary.BigEndian.Uint16(data[offset:(offset + 2)])
 			route, ok := codes[code]
 			if !ok {

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -1,9 +1,17 @@
 package message
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
+
+func appendStringParts(dst []byte, parts ...string) []byte {
+	for _, part := range parts {
+		dst = append(dst, part...)
+	}
+	return dst
+}
 
 func TestEncode(t *testing.T) {
 	dict := map[string]uint16{
@@ -160,5 +168,178 @@ func TestEncode(t *testing.T) {
 
 	if !reflect.DeepEqual(m8, dm8) {
 		t.Error("not equal")
+	}
+}
+
+func TestEncodeAllocationsStayLow(t *testing.T) {
+	SetDictionary(map[string]uint16{
+		"alloc.compressed": 0x1234,
+	})
+
+	tests := []struct {
+		name string
+		msg  *Message
+		want []byte
+	}{
+		{
+			name: "uncompressed request",
+			msg: &Message{
+				Type:  Request,
+				ID:    300,
+				Route: "alloc.request",
+				Data:  []byte("payload"),
+			},
+			want: appendStringParts(
+				[]byte{byte(Request << 1), 0xac, 0x02, byte(len("alloc.request"))},
+				"alloc.request",
+				"payload",
+			),
+		},
+		{
+			name: "compressed notify",
+			msg: &Message{
+				Type:  Notify,
+				Route: "alloc.compressed",
+				Data:  []byte("payload"),
+			},
+			want: appendStringParts(
+				[]byte{byte(Notify<<1) | msgRouteCompressMask, 0x12, 0x34},
+				"payload",
+			),
+		},
+		{
+			name: "response",
+			msg: &Message{
+				Type: Response,
+				ID:   300,
+				Data: []byte("payload"),
+			},
+			want: appendStringParts(
+				[]byte{byte(Response << 1), 0xac, 0x02},
+				"payload",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var encoded []byte
+			var err error
+			allocs := testing.AllocsPerRun(1000, func() {
+				encoded, err = Encode(tt.msg)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if allocs > 1 {
+				t.Fatalf("Encode allocations = %.1f, want <= 1", allocs)
+			}
+			if !reflect.DeepEqual(tt.want, encoded) {
+				t.Fatalf("encoded message changed: want %v, got %v", tt.want, encoded)
+			}
+		})
+	}
+}
+
+func TestDecodeMalformedCompressedRouteReturnsError(t *testing.T) {
+	data := []byte{byte(Notify<<1) | msgRouteCompressMask, 0x12}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Decode panicked on truncated compressed route: %v", r)
+		}
+	}()
+
+	_, err := Decode(data)
+	if !errors.Is(err, ErrWrongMessage) {
+		t.Fatalf("Decode error = %v, want %v", err, ErrWrongMessage)
+	}
+}
+
+func TestDecodeMalformedMessagesReturnExpectedErrors(t *testing.T) {
+	delete(codes, 0xffff)
+
+	tests := []struct {
+		name string
+		data []byte
+		want error
+	}{
+		{
+			name: "too short",
+			data: []byte{byte(Notify << 1)},
+			want: ErrInvalidMessage,
+		},
+		{
+			name: "wrong type",
+			data: []byte{byte(0x04 << 1), 0x00},
+			want: ErrWrongMessageType,
+		},
+		{
+			name: "uncompressed route length exceeds payload",
+			data: []byte{byte(Notify << 1), 0x05, 'a', 'b'},
+			want: ErrWrongMessage,
+		},
+		{
+			name: "unknown compressed route code",
+			data: []byte{byte(Notify<<1) | msgRouteCompressMask, 0xff, 0xff},
+			want: ErrRouteInfoNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Decode(tt.data)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Decode error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	SetDictionary(map[string]uint16{
+		"bench.compressed": 0x2345,
+	})
+
+	tests := []struct {
+		name string
+		msg  *Message
+	}{
+		{
+			name: "uncompressed_request",
+			msg: &Message{
+				Type:  Request,
+				ID:    300,
+				Route: "bench.request",
+				Data:  []byte("payload"),
+			},
+		},
+		{
+			name: "compressed_notify",
+			msg: &Message{
+				Type:  Notify,
+				Route: "bench.compressed",
+				Data:  []byte("payload"),
+			},
+		},
+		{
+			name: "response",
+			msg: &Message{
+				Type: Response,
+				ID:   300,
+				Data: []byte("payload"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := Encode(tt.msg); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Context

This PR keeps the existing backend handling behavior intact while tightening performance-sensitive encoding paths and adding guard coverage around the cluster HTTP/SSE behavior that was reviewed.

## Changes

- Pre-size message encode buffers and append route strings directly to reduce allocations.
- Add malformed message/packet guard tests, including truncated compressed routes returning errors instead of panicking.
- Fix `Node.decreaseConnection` locking so concurrent connection accounting is race-clean.
- Generate default SSE session IDs with crypto randomness while preserving numeric string format and the existing header/query/cookie sources.
- Extract default CORS/SSE helpers and add guard tests that document current open-origin/current-source behavior without changing it.
- Harden `httpAgent` close/post-close paths to return `ErrBrokenPipe` instead of panicking, with concurrency regression tests.
- Fix example compile/vet blocker by formatting `Session.UID()` numerically instead of `string(int64)`.

## Verification

- `gofmt -w cluster/http_agent.go cluster/http_agent_internal_test.go cluster/node.go cluster/node_internal_test.go examples/cluster/main.go internal/codec/codec_test.go internal/message/message.go internal/message/message_test.go`
- `go test ./internal/codec ./internal/message -count=1` passed
- `go test ./... -run '^$'` passed
- `go test ./cluster -run 'TestHTTPAgentMethodsReturnErrBrokenPipeAfterClose|TestHTTPAgentConcurrentCloseAndMethodsRaceFree|TestHTTPAgentOpenPathStillWorks|TestDecreaseConnectionConcurrentAccess|TestGenerateSessionIDIsNumericAndNotTimestamp|TestDefaultCORSHeadersAndPreflightBehavior|TestSSESessionIDFromRequestAcceptsCurrentSources|TestSetSSESessionCookieKeepsNumericCookieBehavior|TestDefaultCheckOriginAllowsWebSocketOrigin' -count=1` passed
- `go build ./...` passed
- `go test -race ./cluster -run 'TestHTTPAgentMethodsReturnErrBrokenPipeAfterClose|TestHTTPAgentConcurrentCloseAndMethodsRaceFree|TestHTTPAgentOpenPathStillWorks|TestDecreaseConnectionConcurrentAccess|TestGenerateSessionIDIsNumericAndNotTimestamp|TestDefaultCORSHeadersAndPreflightBehavior|TestSSESessionIDFromRequestAcceptsCurrentSources|TestSetSSESessionCookieKeepsNumericCookieBehavior|TestDefaultCheckOriginAllowsWebSocketOrigin' -count=1` passed; macOS linker emitted an LC_DYSYMTAB warning but the command exited 0
- `git diff --check` passed

## Risks and rollback

- The default CORS and SSE session source policy is intentionally documented by tests, not restricted in this PR, to avoid changing current backend behavior.
- Full `go test ./...` without `-run '^$'` was not used as completion evidence because the broader cluster integration suite can hang outside this focused scope.
- Rollback is a normal revert of this commit.
