### PR TITLE
fix(cluster): repair stale member routing on rolling rollouts (#7)

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -111,12 +111,12 @@ func (c *cluster) Register(_ context.Context, req *clusterpb.RegisterRequest) (*
 	c.currentNode.handler.replaceRemoteService(req.MemberInfo)
 	c.mu.Lock()
 	c.members = append(c.members, &Member{isMaster: false, memberInfo: req.MemberInfo, lastHeartbeatAt: time.Now()})
+	// Cancel any queued delete-propagation for this address WHILE holding c.mu,
+	// atomically with making the member live again. Cancelling after unlocking
+	// raced a concurrent Unregister that could re-queue a legitimate delete in
+	// the gap, which the late cancel would then erase (issue #7, review round 2).
+	c.cancelPendingDeleteLocked(req.MemberInfo.ServiceAddr)
 	c.mu.Unlock()
-
-	// A node that just (re)registered is alive again: cancel any queued
-	// delete-propagation for its address so peers are not later taught to drop a
-	// member that came back (issue #7).
-	c.cancelPendingDelete(req.MemberInfo.ServiceAddr)
 
 	log.Println("New peer register to cluster", req.MemberInfo.ServiceAddr)
 
@@ -255,22 +255,21 @@ func (c *cluster) Heartbeat(_ context.Context, req *clusterpb.HeartbeatRequest) 
 			memberInfo:      req.MemberInfo,
 			lastHeartbeatAt: time.Now(),
 		})
-		// Install the recovered member's routes while still holding c.mu so a
-		// concurrent Unregister for the same address cannot remove the member and
-		// then have this heartbeat reinstall its routes afterwards (issue #7,
-		// review round 1). c.mu -> h.mu order is safe: no handler method acquires
-		// c.mu.
+		// Install the recovered member's routes AND cancel any stale delete for
+		// it while still holding c.mu, atomically with making it live again.
+		// Doing either after unlocking raced a concurrent Unregister: the route
+		// could be reinstalled after removal, or a freshly re-queued delete could
+		// be erased by a late cancel (issue #7, review rounds 1 & 2). c.mu -> h.mu
+		// order is safe: no handler method acquires c.mu.
 		c.currentNode.handler.replaceRemoteService(req.MemberInfo)
+		c.cancelPendingDeleteLocked(addr)
 	}
 	c.mu.Unlock()
 
 	if !isHit {
-		// The master did not know this member (e.g. it restarted and lost its
-		// in-memory registry); its services were re-learned above. Drop any stale
-		// delete still queued for it. A *stable* heartbeat skips all of this and
-		// only refreshes the timestamp, so steady-state heartbeats stay O(1) with
-		// no route sync or broadcast (issue #7, fixes 5 & 7).
-		c.cancelPendingDelete(addr)
+		// A *stable* heartbeat skips all of the above and only refreshes the
+		// timestamp, so steady-state heartbeats stay O(1) with no route sync or
+		// broadcast (issue #7, fixes 5 & 7).
 		log.Println("Heartbeat peer register to cluster", addr)
 	}
 
@@ -573,12 +572,13 @@ func (c *cluster) flushPendingDeletes(peerAddr string) {
 	}
 }
 
-// cancelPendingDelete removes deletedAddr from every peer's retry set, used when
-// a node (re)registers so peers are not later taught to drop a member that has
-// returned under the same address (issue #7).
-func (c *cluster) cancelPendingDelete(deletedAddr string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// cancelPendingDeleteLocked removes deletedAddr from every peer's retry set, used
+// when a node (re)registers so peers are not later taught to drop a member that
+// has returned under the same address (issue #7). The caller must hold c.mu so
+// the cancel runs atomically with the membership change that justifies it,
+// instead of in a post-unlock window where a concurrent Unregister could have
+// queued a fresh, legitimate delete (issue #7, review round 2).
+func (c *cluster) cancelPendingDeleteLocked(deletedAddr string) {
 	for peer, set := range c.pendingDeletes {
 		delete(set, deletedAddr)
 		if len(set) == 0 {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -48,10 +48,26 @@ type cluster struct {
 	heartbeatStop chan struct{}
 	heartbeatDone chan struct{}
 	heartbeatOnce sync.Once
+
+	// pendingDeletes queues DelMember notifications that failed to reach a live
+	// peer during Unregister, keyed by the recipient peer's ServiceAddr -> set of
+	// member addresses it must still drop. Retried on that peer's next heartbeat
+	// so a peer that briefly missed a delete cannot route to an unregistered pod
+	// indefinitely (issue #7, fix 4). Guarded by mu.
+	pendingDeletes map[string]map[string]struct{}
+
+	// notifyDelMember sends one DelMember to a peer. Indirected so tests can
+	// observe/stub the fan-out without a live gRPC peer; wired to sendDelMember in
+	// newCluster.
+	notifyDelMember func(peerAddr, deletedAddr string) error
 }
 
 func newCluster(currentNode *Node) *cluster {
-	c := &cluster{currentNode: currentNode}
+	c := &cluster{
+		currentNode:    currentNode,
+		pendingDeletes: map[string]map[string]struct{}{},
+	}
+	c.notifyDelMember = c.sendDelMember
 	if currentNode.IsMaster {
 		c.checkMemberHeartbeat()
 	}
@@ -90,10 +106,17 @@ func (c *cluster) Register(_ context.Context, req *clusterpb.RegisterRequest) (*
 		resp.Members = append(resp.Members, m.memberInfo)
 	}
 
-	c.currentNode.handler.addRemoteService(req.MemberInfo)
+	// Clean-replace the (re)joining member's routes so a changed/shrunk service
+	// set cannot leave stale services routable for this address (issue #7).
+	c.currentNode.handler.replaceRemoteService(req.MemberInfo)
 	c.mu.Lock()
 	c.members = append(c.members, &Member{isMaster: false, memberInfo: req.MemberInfo, lastHeartbeatAt: time.Now()})
 	c.mu.Unlock()
+
+	// A node that just (re)registered is alive again: cancel any queued
+	// delete-propagation for its address so peers are not later taught to drop a
+	// member that came back (issue #7).
+	c.cancelPendingDelete(req.MemberInfo.ServiceAddr)
 
 	log.Println("New peer register to cluster", req.MemberInfo.ServiceAddr)
 
@@ -169,12 +192,12 @@ func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest
 	if c.rpcClient != nil {
 		c.rpcClient.removePool(req.ServiceAddr)
 	}
+	c.dropPendingDeletesForPeer(req.ServiceAddr)
 
 	log.Println("Exists peer unregister to cluster", req.ServiceAddr)
 
 	// Notify the remaining peers best-effort; a failed peer is logged and
 	// skipped rather than aborting removal, and each call is bounded (H25).
-	delMember := &clusterpb.DelMemberRequest{ServiceAddr: req.ServiceAddr}
 	for _, m := range snapshot {
 		if m.memberInfo.ServiceAddr == req.ServiceAddr {
 			// this node is down.
@@ -183,17 +206,12 @@ func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest
 		if m.MemberInfo().ServiceAddr == c.currentNode.ServiceAddr {
 			continue
 		}
-		pool, err := c.rpcClient.getConnPool(m.memberInfo.ServiceAddr)
-		if err != nil {
-			log.Errorf("cluster: notify del member %s -> %s failed: %v", req.ServiceAddr, m.memberInfo.ServiceAddr, err)
-			continue
-		}
-		client := clusterpb.NewMemberClient(pool.Get())
-		ctx, cancel := context.WithTimeout(context.Background(), remoteRPCTimeout)
-		_, err = client.DelMember(ctx, delMember)
-		cancel()
-		if err != nil {
-			log.Errorf("cluster: notify del member %s -> %s failed: %v", req.ServiceAddr, m.memberInfo.ServiceAddr, err)
+		if err := c.notifyDelMember(m.memberInfo.ServiceAddr, req.ServiceAddr); err != nil {
+			// The peer was unreachable: queue the delete so it is retried on the
+			// peer's next heartbeat. Without this, a peer that briefly missed the
+			// notification routes to the unregistered pod indefinitely (issue #7).
+			log.Errorf("cluster: notify del member %s -> %s failed (queued for retry): %v", req.ServiceAddr, m.memberInfo.ServiceAddr, err)
+			c.recordPendingDelete(m.memberInfo.ServiceAddr, req.ServiceAddr)
 		}
 	}
 
@@ -221,29 +239,42 @@ func (c *cluster) Heartbeat(_ context.Context, req *clusterpb.HeartbeatRequest) 
 	if req == nil || req.MemberInfo == nil || req.MemberInfo.ServiceAddr == "" {
 		return nil, ErrInvalidRegisterReq
 	}
+	addr := req.MemberInfo.ServiceAddr
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	log.Println("Receive Heartbeat from: ", req.MemberInfo.Label)
-
 	isHit := false
 	for i, m := range c.members {
-		if m.MemberInfo().GetServiceAddr() == req.GetMemberInfo().GetServiceAddr() {
+		if m.MemberInfo().GetServiceAddr() == addr {
 			c.members[i].lastHeartbeatAt = time.Now()
 			isHit = true
 		}
 	}
 	if !isHit {
-		// master local not binding this node, other members do not need to be notified, because this node registered.
-		// maybe the master process reload
-		m := &Member{
+		c.members = append(c.members, &Member{
 			isMaster:        false,
-			memberInfo:      req.GetMemberInfo(),
+			memberInfo:      req.MemberInfo,
 			lastHeartbeatAt: time.Now(),
-		}
-		c.members = append(c.members, m)
-		c.currentNode.handler.addRemoteService(req.MemberInfo)
-		log.Println("Heartbeat peer register to cluster", req.MemberInfo.ServiceAddr)
+		})
 	}
+	c.mu.Unlock()
+
+	if !isHit {
+		// The master did not know this member (e.g. it restarted and lost its
+		// in-memory registry). Re-learn the member's services and drop any stale
+		// delete still queued for it (issue #7, fixes 5 & 7). A *stable* heartbeat
+		// skips this entirely and only refreshes the timestamp above, so
+		// steady-state heartbeats stay O(1) with no route sync or broadcast.
+		c.currentNode.handler.replaceRemoteService(req.MemberInfo)
+		c.cancelPendingDelete(addr)
+		log.Println("Heartbeat peer register to cluster", addr)
+	}
+
+	// Retry any delete notifications this peer missed while it was briefly
+	// unreachable, now that it has proven liveness by heartbeating. Gated on
+	// pending work, so a steady-state cluster does no extra work (issue #7,
+	// fixes 4 & 5).
+	c.flushPendingDeletes(addr)
+
 	return &clusterpb.HeartbeatResponse{}, nil
 }
 
@@ -428,6 +459,7 @@ func (c *cluster) delMember(addr string) {
 	if c.rpcClient != nil {
 		c.rpcClient.removePool(addr)
 	}
+	c.dropPendingDeletesForPeer(addr)
 }
 
 // addLocalMember appends a member under the lock. Used by node startup to
@@ -450,4 +482,98 @@ func (c *cluster) isKnownAddr(addr string) bool {
 		}
 	}
 	return false
+}
+
+// maxPendingDeletePeers bounds how many distinct peers may hold queued
+// delete-retries, so an endlessly unreachable peer cannot grow the ledger
+// without limit; beyond it the stale target is reclaimed by heartbeat timeout.
+const maxPendingDeletePeers = 4096
+
+// recordPendingDelete queues deletedAddr to be re-sent to peerAddr on its next
+// heartbeat after a live DelMember broadcast to peerAddr failed (issue #7).
+func (c *cluster) recordPendingDelete(peerAddr, deletedAddr string) {
+	if peerAddr == "" || deletedAddr == "" || peerAddr == deletedAddr {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.pendingDeletes == nil {
+		c.pendingDeletes = map[string]map[string]struct{}{}
+	}
+	set := c.pendingDeletes[peerAddr]
+	if set == nil {
+		if len(c.pendingDeletes) >= maxPendingDeletePeers {
+			return
+		}
+		set = map[string]struct{}{}
+		c.pendingDeletes[peerAddr] = set
+	}
+	set[deletedAddr] = struct{}{}
+}
+
+// flushPendingDeletes re-sends every queued delete to peerAddr, which has just
+// proven liveness by heartbeating. Successful sends drop from the ledger;
+// failures are re-queued. RPCs run without the lock held so a slow peer cannot
+// stall heartbeat processing (issue #7, fixes 4 & 5).
+func (c *cluster) flushPendingDeletes(peerAddr string) {
+	c.mu.Lock()
+	set := c.pendingDeletes[peerAddr]
+	if len(set) == 0 {
+		c.mu.Unlock()
+		return
+	}
+	pending := make([]string, 0, len(set))
+	for a := range set {
+		pending = append(pending, a)
+	}
+	delete(c.pendingDeletes, peerAddr)
+	c.mu.Unlock()
+
+	for _, deletedAddr := range pending {
+		if err := c.notifyDelMember(peerAddr, deletedAddr); err != nil {
+			log.Errorf("cluster: retry del member %s -> %s failed (re-queued): %v", deletedAddr, peerAddr, err)
+			c.recordPendingDelete(peerAddr, deletedAddr)
+		} else {
+			log.Infof("cluster: repaired missed del member %s -> %s on heartbeat", deletedAddr, peerAddr)
+		}
+	}
+}
+
+// cancelPendingDelete removes deletedAddr from every peer's retry set, used when
+// a node (re)registers so peers are not later taught to drop a member that has
+// returned under the same address (issue #7).
+func (c *cluster) cancelPendingDelete(deletedAddr string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for peer, set := range c.pendingDeletes {
+		delete(set, deletedAddr)
+		if len(set) == 0 {
+			delete(c.pendingDeletes, peer)
+		}
+	}
+}
+
+// dropPendingDeletesForPeer discards every queued retry destined for peerAddr,
+// used when that peer itself leaves the cluster (issue #7).
+func (c *cluster) dropPendingDeletesForPeer(peerAddr string) {
+	c.mu.Lock()
+	delete(c.pendingDeletes, peerAddr)
+	c.mu.Unlock()
+}
+
+// sendDelMember delivers one DelMember RPC; it is the production implementation
+// behind the notifyDelMember test seam.
+func (c *cluster) sendDelMember(peerAddr, deletedAddr string) error {
+	if c.rpcClient == nil {
+		return fmt.Errorf("cluster: rpc client is nil")
+	}
+	pool, err := c.rpcClient.getConnPool(peerAddr)
+	if err != nil {
+		return err
+	}
+	client := clusterpb.NewMemberClient(pool.Get())
+	ctx, cancel := context.WithTimeout(context.Background(), remoteRPCTimeout)
+	defer cancel()
+	_, err = client.DelMember(ctx, &clusterpb.DelMemberRequest{ServiceAddr: deletedAddr})
+	return err
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -307,6 +307,12 @@ func (c *cluster) checkMemberHeartbeat() {
 				log.Println("Heartbeat unregister error", err)
 			}
 		}
+
+		// Reconcile the ledger against current membership so retries queued for a
+		// peer that has since left (e.g. a peer removed during another
+		// Unregister's snapshot-based fan-out window) cannot linger forever and
+		// fill the bound under churn (issue #7, review round 5).
+		c.pruneStalePendingDeletes()
 	}
 	go func() {
 		defer close(c.heartbeatDone)
@@ -600,6 +606,28 @@ func (c *cluster) dropPendingDeletesForPeer(peerAddr string) {
 	c.mu.Lock()
 	delete(c.pendingDeletes, peerAddr)
 	c.mu.Unlock()
+}
+
+// pruneStalePendingDeletes drops queued delete-retries for peers that are no
+// longer members. Such a peer never heartbeats to flush its entry, so without
+// periodic pruning the ledger could accumulate dead keys (e.g. a peer removed
+// during another Unregister's snapshot-based fan-out) and fill its bound under
+// churn (issue #7, review round 5). Runs on the master heartbeat tick.
+func (c *cluster) pruneStalePendingDeletes() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.pendingDeletes) == 0 {
+		return
+	}
+	alive := make(map[string]struct{}, len(c.members))
+	for _, m := range c.members {
+		alive[m.memberInfo.ServiceAddr] = struct{}{}
+	}
+	for peer := range c.pendingDeletes {
+		if _, ok := alive[peer]; !ok {
+			delete(c.pendingDeletes, peer)
+		}
+	}
 }
 
 // sendDelMember delivers one DelMember RPC; it is the production implementation

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -81,44 +81,35 @@ func (c *cluster) Register(_ context.Context, req *clusterpb.RegisterRequest) (*
 	}
 	resp := &clusterpb.RegisterResponse{}
 	c.mu.Lock()
+	// Remove any existing entry for this address (crash/rollover re-register),
+	// snapshot the surviving peers for the response + fan-out, then add the new
+	// member and install its routes — all under one c.mu critical section so
+	// membership and the local route table never diverge for this address and a
+	// concurrent same-address Unregister cannot interleave a route/member split
+	// (issue #7, review rounds 3 & 4). c.mu -> h.mu is the global lock order;
+	// handler methods take h.mu, never c.mu, and do no network I/O. The peer RPC
+	// fan-out below stays outside the lock (H25).
 	for k, m := range c.members {
 		if m.memberInfo.ServiceAddr == req.MemberInfo.ServiceAddr {
-			// 节点异常崩溃，不会执行unregister，此时再次启动该节点，由于已存在注册信息，将再也无法成功注册，这里做个修改，先移除后重新注册
 			if k >= len(c.members)-1 {
 				c.members = c.members[:k]
 			} else {
 				c.members = append(c.members[:k], c.members[k+1:]...)
 			}
 			break
-			//return nil, fmt.Errorf("address %s has registered", req.MemberInfo.ServiceAddr)
 		}
 	}
-	// Snapshot the surviving members under the lock so the fan-out below never
-	// races concurrent membership mutations on the backing array (H4).
 	snapshot := make([]*Member, len(c.members))
 	copy(snapshot, c.members)
-	c.mu.Unlock()
-
-	// Register the new member locally FIRST so a single unreachable or stale
-	// peer cannot block the join (and leave the registering node retrying
-	// forever). Peer notification below is best-effort (H25).
-	for _, m := range snapshot {
-		resp.Members = append(resp.Members, m.memberInfo)
-	}
-
-	// Append the member AND install its routes under one c.mu critical section so
-	// membership and the local route table cannot diverge: installing the route
-	// outside the lock raced a concurrent same-address Unregister, which could
-	// remove the member while this reinstalled its route, leaving a route for a
-	// non-member (issue #7, review round 3). The pending-delete cancel is in the
-	// same section so a concurrent Unregister cannot re-queue a delete the cancel
-	// then erases (review round 2). c.mu -> h.mu order is safe: handler methods
-	// never acquire c.mu and do no network I/O.
-	c.mu.Lock()
 	c.members = append(c.members, &Member{isMaster: false, memberInfo: req.MemberInfo, lastHeartbeatAt: time.Now()})
 	c.currentNode.handler.replaceRemoteService(req.MemberInfo)
 	c.cancelPendingDeleteLocked(req.MemberInfo.ServiceAddr)
 	c.mu.Unlock()
+
+	// Tell the (re)joining node about the surviving peers (snapshot excludes it).
+	for _, m := range snapshot {
+		resp.Members = append(resp.Members, m.memberInfo)
+	}
 
 	log.Println("New peer register to cluster", req.MemberInfo.ServiceAddr)
 
@@ -430,42 +421,52 @@ func (c *cluster) initMembers(members []*clusterpb.MemberInfo) {
 
 func (c *cluster) addMember(info *clusterpb.MemberInfo) {
 	c.mu.Lock()
-	var found bool
+	c.addMemberLocked(info)
+	c.mu.Unlock()
+}
+
+// addMemberLocked upserts a member by service address. The caller must hold c.mu
+// so membership and the local route table can be updated atomically (issue #7,
+// review round 4).
+func (c *cluster) addMemberLocked(info *clusterpb.MemberInfo) {
 	for _, member := range c.members {
 		if member.memberInfo.ServiceAddr == info.ServiceAddr {
 			member.memberInfo = info
-			found = true
-			break
+			return
 		}
 	}
-	if !found {
-		c.members = append(c.members, &Member{
-			memberInfo: info,
-		})
-	}
-	c.mu.Unlock()
+	c.members = append(c.members, &Member{
+		memberInfo: info,
+	})
 }
 
 func (c *cluster) delMember(addr string) {
 	c.mu.Lock()
-	var index = -1
+	c.removeMemberLocked(addr)
+	c.mu.Unlock()
+	c.releaseDepartedPeer(addr)
+}
+
+// removeMemberLocked removes a member by service address from c.members. The
+// caller must hold c.mu so membership and the local route table can be updated
+// atomically (issue #7, review round 4).
+func (c *cluster) removeMemberLocked(addr string) {
 	for i, member := range c.members {
 		if member.memberInfo.ServiceAddr == addr {
-			index = i
-			break
+			if i >= len(c.members)-1 {
+				c.members = c.members[:i]
+			} else {
+				c.members = append(c.members[:i], c.members[i+1:]...)
+			}
+			return
 		}
 	}
-	if index != -1 {
-		if index >= len(c.members)-1 {
-			c.members = c.members[:index]
-		} else {
-			c.members = append(c.members[:index], c.members[index+1:]...)
-		}
-	}
-	c.mu.Unlock()
+}
 
-	// Close the outbound connection pool to the departed member so its gRPC
-	// ClientConns/goroutines are reclaimed on member removal (M3).
+// releaseDepartedPeer closes the outbound connection pool and drops queued
+// delete-retries for a peer that left the cluster. Kept OUT of c.mu because pool
+// teardown does network work (M3).
+func (c *cluster) releaseDepartedPeer(addr string) {
 	if c.rpcClient != nil {
 		c.rpcClient.removePool(addr)
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -255,16 +255,21 @@ func (c *cluster) Heartbeat(_ context.Context, req *clusterpb.HeartbeatRequest) 
 			memberInfo:      req.MemberInfo,
 			lastHeartbeatAt: time.Now(),
 		})
+		// Install the recovered member's routes while still holding c.mu so a
+		// concurrent Unregister for the same address cannot remove the member and
+		// then have this heartbeat reinstall its routes afterwards (issue #7,
+		// review round 1). c.mu -> h.mu order is safe: no handler method acquires
+		// c.mu.
+		c.currentNode.handler.replaceRemoteService(req.MemberInfo)
 	}
 	c.mu.Unlock()
 
 	if !isHit {
 		// The master did not know this member (e.g. it restarted and lost its
-		// in-memory registry). Re-learn the member's services and drop any stale
-		// delete still queued for it (issue #7, fixes 5 & 7). A *stable* heartbeat
-		// skips this entirely and only refreshes the timestamp above, so
-		// steady-state heartbeats stay O(1) with no route sync or broadcast.
-		c.currentNode.handler.replaceRemoteService(req.MemberInfo)
+		// in-memory registry); its services were re-learned above. Drop any stale
+		// delete still queued for it. A *stable* heartbeat skips all of this and
+		// only refreshes the timestamp, so steady-state heartbeats stay O(1) with
+		// no route sync or broadcast (issue #7, fixes 5 & 7).
 		c.cancelPendingDelete(addr)
 		log.Println("Heartbeat peer register to cluster", addr)
 	}
@@ -489,6 +494,12 @@ func (c *cluster) isKnownAddr(addr string) bool {
 // without limit; beyond it the stale target is reclaimed by heartbeat timeout.
 const maxPendingDeletePeers = 4096
 
+// maxDeleteRetriesPerHeartbeat bounds how many queued deletes a single heartbeat
+// flushes, so a peer with a large backlog cannot pin the heartbeat handler on
+// synchronous DelMember RPCs; the remainder is retried on the next heartbeat
+// (issue #7, review round 1).
+const maxDeleteRetriesPerHeartbeat = 64
+
 // recordPendingDelete queues deletedAddr to be re-sent to peerAddr on its next
 // heartbeat after a live DelMember broadcast to peerAddr failed (issue #7).
 func (c *cluster) recordPendingDelete(peerAddr, deletedAddr string) {
@@ -503,6 +514,7 @@ func (c *cluster) recordPendingDelete(peerAddr, deletedAddr string) {
 	set := c.pendingDeletes[peerAddr]
 	if set == nil {
 		if len(c.pendingDeletes) >= maxPendingDeletePeers {
+			log.Warn(fmt.Sprintf("cluster: pending-delete ledger full (%d peers); dropping retry to %s for departed %s; that peer may keep a stale route until it re-registers (issue #7)", maxPendingDeletePeers, peerAddr, deletedAddr))
 			return
 		}
 		set = map[string]struct{}{}
@@ -511,10 +523,13 @@ func (c *cluster) recordPendingDelete(peerAddr, deletedAddr string) {
 	set[deletedAddr] = struct{}{}
 }
 
-// flushPendingDeletes re-sends every queued delete to peerAddr, which has just
-// proven liveness by heartbeating. Successful sends drop from the ledger;
-// failures are re-queued. RPCs run without the lock held so a slow peer cannot
-// stall heartbeat processing (issue #7, fixes 4 & 5).
+// flushPendingDeletes re-sends queued deletes to peerAddr, which has just proven
+// liveness by heartbeating. It drops any target that is a live member again
+// (re-registered) so a peer is never told to drop a rejoined pod, caps the batch
+// so a large backlog cannot pin the heartbeat handler on synchronous RPCs (the
+// remainder is retried next beat), and re-checks liveness right before each
+// send. Successful sends leave the ledger; failures are re-queued. RPCs run
+// without the lock held (issue #7, fixes 4 & 5; review round 1).
 func (c *cluster) flushPendingDeletes(peerAddr string) {
 	c.mu.Lock()
 	set := c.pendingDeletes[peerAddr]
@@ -522,14 +537,33 @@ func (c *cluster) flushPendingDeletes(peerAddr string) {
 		c.mu.Unlock()
 		return
 	}
-	pending := make([]string, 0, len(set))
-	for a := range set {
-		pending = append(pending, a)
+	alive := make(map[string]struct{}, len(c.members))
+	for _, m := range c.members {
+		alive[m.memberInfo.ServiceAddr] = struct{}{}
 	}
-	delete(c.pendingDeletes, peerAddr)
+	pending := make([]string, 0, len(set))
+	for addr := range set {
+		if _, ok := alive[addr]; ok {
+			delete(set, addr) // re-registered -> the queued delete is stale, drop it
+			continue
+		}
+		if len(pending) >= maxDeleteRetriesPerHeartbeat {
+			break
+		}
+		pending = append(pending, addr)
+		delete(set, addr)
+	}
+	if len(set) == 0 {
+		delete(c.pendingDeletes, peerAddr)
+	}
 	c.mu.Unlock()
 
 	for _, deletedAddr := range pending {
+		// The target may have re-registered between the snapshot above and now;
+		// never tell a peer to drop a currently-registered member (issue #7).
+		if c.isKnownAddr(deletedAddr) {
+			continue
+		}
 		if err := c.notifyDelMember(peerAddr, deletedAddr); err != nil {
 			log.Errorf("cluster: retry del member %s -> %s failed (re-queued): %v", deletedAddr, peerAddr, err)
 			c.recordPendingDelete(peerAddr, deletedAddr)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -106,15 +106,17 @@ func (c *cluster) Register(_ context.Context, req *clusterpb.RegisterRequest) (*
 		resp.Members = append(resp.Members, m.memberInfo)
 	}
 
-	// Clean-replace the (re)joining member's routes so a changed/shrunk service
-	// set cannot leave stale services routable for this address (issue #7).
-	c.currentNode.handler.replaceRemoteService(req.MemberInfo)
+	// Append the member AND install its routes under one c.mu critical section so
+	// membership and the local route table cannot diverge: installing the route
+	// outside the lock raced a concurrent same-address Unregister, which could
+	// remove the member while this reinstalled its route, leaving a route for a
+	// non-member (issue #7, review round 3). The pending-delete cancel is in the
+	// same section so a concurrent Unregister cannot re-queue a delete the cancel
+	// then erases (review round 2). c.mu -> h.mu order is safe: handler methods
+	// never acquire c.mu and do no network I/O.
 	c.mu.Lock()
 	c.members = append(c.members, &Member{isMaster: false, memberInfo: req.MemberInfo, lastHeartbeatAt: time.Now()})
-	// Cancel any queued delete-propagation for this address WHILE holding c.mu,
-	// atomically with making the member live again. Cancelling after unlocking
-	// raced a concurrent Unregister that could re-queue a legitimate delete in
-	// the gap, which the late cancel would then erase (issue #7, review round 2).
+	c.currentNode.handler.replaceRemoteService(req.MemberInfo)
 	c.cancelPendingDeleteLocked(req.MemberInfo.ServiceAddr)
 	c.mu.Unlock()
 
@@ -170,10 +172,13 @@ func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest
 		return nil, fmt.Errorf("address %s has not registered", req.ServiceAddr)
 	}
 
-	// Remove the departed member from the master/local registry FIRST so a
-	// single unreachable peer cannot block removal and leave a stale routable
-	// address (plus a heartbeat retry loop) (H25).
-	c.currentNode.handler.delMember(req.ServiceAddr)
+	// Remove the member from membership AND purge its local routes under one c.mu
+	// critical section so the two cannot diverge: purging the route outside the
+	// lock raced a concurrent same-address Register that could reinstall the route
+	// after this removed the member, leaving a route for a non-member (issue #7,
+	// review round 3). c.mu -> h.mu order is safe (handler methods never take
+	// c.mu and do no network I/O); the best-effort peer RPC fan-out below stays
+	// outside the lock (H25).
 	c.mu.Lock()
 	for i, m := range c.members {
 		if m.memberInfo.ServiceAddr == req.ServiceAddr {
@@ -185,6 +190,7 @@ func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest
 			break
 		}
 	}
+	c.currentNode.handler.delMember(req.ServiceAddr)
 	c.mu.Unlock()
 
 	// Close the outbound connection pool to the departed member so its gRPC

--- a/cluster/handler.go
+++ b/cluster/handler.go
@@ -43,8 +43,8 @@ import (
 	"github.com/lonng/nano/internal/packet"
 	"github.com/lonng/nano/metrics"
 	"github.com/lonng/nano/pipeline"
-	"github.com/lonng/nano/serialize"
 	"github.com/lonng/nano/scheduler"
+	"github.com/lonng/nano/serialize"
 	"github.com/lonng/nano/session"
 )
 
@@ -215,6 +215,38 @@ func (h *LocalHandler) addRemoteService(member *clusterpb.MemberInfo) {
 		}
 		log.Println("Register remote service", s)
 		h.remoteServices[s] = append(filtered, member)
+	}
+}
+
+// replaceRemoteService atomically drops every existing route entry for
+// member.ServiceAddr and installs the member's current service list, so a
+// rejoin that changes or shrinks its advertised services leaves no stale
+// service selectable for that address (issue #7, fixes 2 & 7). addRemoteService
+// only refreshes the services the member still advertises, so a service it
+// dropped on rejoin would otherwise remain routable under the old address.
+func (h *LocalHandler) replaceRemoteService(member *clusterpb.MemberInfo) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	addr := member.ServiceAddr
+	// 1) Purge every existing entry for this address across all services.
+	for name, members := range h.remoteServices {
+		kept := members[:0]
+		for _, m := range members {
+			if m.ServiceAddr != addr {
+				kept = append(kept, m)
+			}
+		}
+		if len(kept) == 0 {
+			delete(h.remoteServices, name)
+		} else {
+			h.remoteServices[name] = kept
+		}
+	}
+	// 2) Install the member's current service list.
+	for _, s := range member.Services {
+		log.Println("Register remote service", s)
+		h.remoteServices[s] = append(h.remoteServices[s], member)
 	}
 }
 

--- a/cluster/issue7_review_test.go
+++ b/cluster/issue7_review_test.go
@@ -462,3 +462,24 @@ func TestPeerNewMemberDelMemberRaceConsistent(t *testing.T) {
 		}
 	}
 }
+
+// 4d. The master heartbeat tick prunes ledger entries for peers that have left
+// (they never heartbeat to flush), so a snapshot-fan-out race cannot accumulate
+// dead keys and fill the bound (issue #7, review round 5).
+func TestPruneStalePendingDeletesDropsDepartedPeers(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+
+	c.addMember(memberInfo("live-peer:1", "Svc")) // a live member peer
+	c.recordPendingDelete("live-peer:1", "dead-target:1")
+	c.recordPendingDelete("gone-peer:1", "dead-target:1") // never registered as a member
+
+	c.pruneStalePendingDeletes()
+
+	if pendingCount(c, "live-peer:1") != 1 {
+		t.Fatal("prune dropped a queued delete for a still-live member peer")
+	}
+	if pendingCount(c, "gone-peer:1") != 0 {
+		t.Fatal("prune did not drop the queued delete for a departed (non-member) peer")
+	}
+}

--- a/cluster/issue7_review_test.go
+++ b/cluster/issue7_review_test.go
@@ -410,3 +410,55 @@ func TestRegisterUnregisterRaceMembershipRouteConsistent(t *testing.T) {
 		}
 	}
 }
+
+// A3. The peer DelMember receive path must purge the route to the departed
+// address (the production hop the spy-based retry test stubs out): retry ->
+// peer Node.DelMember -> handler.delMember (issue #7 review round 4).
+func TestPeerDelMemberDropsRoute(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	n := newTestNode()
+	n.handler.addRemoteService(memberInfo("backend:7", "Map"))
+	if !routable(n.cluster, "Map", "backend:7") {
+		t.Fatal("setup: backend:7 should be routable for Map")
+	}
+	if _, err := n.DelMember(context.Background(), &clusterpb.DelMemberRequest{ServiceAddr: "backend:7"}); err != nil {
+		t.Fatalf("DelMember: %v", err)
+	}
+	if routable(n.cluster, "Map", "backend:7") {
+		t.Fatal("Node.DelMember did not purge the peer's route to the departed address")
+	}
+}
+
+// 5d. Stress the peer NewMember vs DelMember interleaving for the same address
+// (a rollover broadcast race on a non-master node). Invariant: peer membership
+// and the local route table agree — member iff routable (issue #7 round 4).
+func TestPeerNewMemberDelMemberRaceConsistent(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	const addr = "backend:9"
+	for iter := 0; iter < 200; iter++ {
+		n := newTestNode()
+		if _, err := n.NewMember(context.Background(), &clusterpb.NewMemberRequest{MemberInfo: memberInfo(addr, "Svc")}); err != nil {
+			t.Fatalf("seed NewMember: %v", err)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = n.NewMember(context.Background(), &clusterpb.NewMemberRequest{MemberInfo: memberInfo(addr, "Svc")})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = n.DelMember(context.Background(), &clusterpb.DelMemberRequest{ServiceAddr: addr})
+		}()
+		close(start)
+		wg.Wait()
+
+		if member, routed := n.cluster.isKnownAddr(addr), routable(n.cluster, "Svc", addr); member != routed {
+			t.Fatalf("iter %d: peer membership/route diverged: isKnownAddr=%v routable=%v", iter, member, routed)
+		}
+	}
+}

--- a/cluster/issue7_review_test.go
+++ b/cluster/issue7_review_test.go
@@ -1,0 +1,303 @@
+// Copyright (c) nano Authors. All Rights Reserved.
+//
+// Regression tests added during the issue #7 review round. They cover the
+// peer-side route replacement, the pending-delete cancel/rejoin race, the
+// per-heartbeat retry batch cap, the ledger bound, and the cleanup paths that
+// the first cut left untested.
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/lonng/nano/cluster/clusterpb"
+	"github.com/lonng/nano/internal/log"
+)
+
+// pendingPeerCount returns the number of peers holding queued deletes.
+func pendingPeerCount(c *cluster) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.pendingDeletes)
+}
+
+// pendingHas reports whether deletedAddr is queued for peerAddr.
+func pendingHas(c *cluster, peerAddr, deletedAddr string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.pendingDeletes[peerAddr][deletedAddr]
+	return ok
+}
+
+// pairDelSpy records notifyDelMember calls and can fail specific (peer,deleted)
+// pairs, so partial-flush behavior can be driven deterministically.
+type pairDelSpy struct {
+	mu    sync.Mutex
+	calls []delCall
+	fail  map[delCall]bool
+}
+
+func (s *pairDelSpy) notify(peer, deleted string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, delCall{peer, deleted})
+	if s.fail[delCall{peer, deleted}] {
+		return errors.New("unreachable")
+	}
+	return nil
+}
+
+func (s *pairDelSpy) count(peer, deleted string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, c := range s.calls {
+		if c.peer == peer && c.deleted == deleted {
+			n++
+		}
+	}
+	return n
+}
+
+// A1. The peer-side NewMember receive path must clean-replace routes, so a
+// same-address rejoin that drops a service purges the stale route on the peer
+// too (issue #7 fix 2/7 end-to-end; the original cut only fixed the master).
+func TestPeerNewMemberReplacesStaleServiceRoutes(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	n := newTestNode()
+
+	// Seed the peer's routing table as if it had learned backend:1 with two
+	// services.
+	n.handler.addRemoteService(memberInfo("backend:1", "Map", "Chat"))
+	if !routable(n.cluster, "Map", "backend:1") || !routable(n.cluster, "Chat", "backend:1") {
+		t.Fatal("setup: backend:1 should be routable for Map and Chat")
+	}
+
+	// backend:1 rolls and re-registers at the same address with only Map; the
+	// master fans a NewMember to this peer.
+	if _, err := n.NewMember(context.Background(), &clusterpb.NewMemberRequest{
+		MemberInfo: memberInfo("backend:1", "Map"),
+	}); err != nil {
+		t.Fatalf("NewMember: %v", err)
+	}
+	if got := routableCount(n.cluster, "Map", "backend:1"); got != 1 {
+		t.Fatalf("Map should remain routable exactly once after peer NewMember, got %d", got)
+	}
+	if routable(n.cluster, "Chat", "backend:1") {
+		t.Fatal("stale Chat route survived a peer NewMember that dropped the service (fix 2/7 not end-to-end)")
+	}
+}
+
+// A2. A rejoin that ADDS a service must make the new service routable (the
+// replacement installs the full current list, not only prunes).
+func TestRejoinAddsServiceRoutable(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+
+	if _, err := c.Register(context.Background(), &clusterpb.RegisterRequest{MemberInfo: memberInfo("127.0.0.1:9001", "Map")}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := c.Register(context.Background(), &clusterpb.RegisterRequest{MemberInfo: memberInfo("127.0.0.1:9001", "Map", "Chat")}); err != nil {
+		t.Fatalf("rejoin: %v", err)
+	}
+	if routableCount(c, "Map", "127.0.0.1:9001") != 1 || routableCount(c, "Chat", "127.0.0.1:9001") != 1 {
+		t.Fatalf("after rejoin-adds-service expected Map=1 Chat=1, got Map=%d Chat=%d",
+			routableCount(c, "Map", "127.0.0.1:9001"), routableCount(c, "Chat", "127.0.0.1:9001"))
+	}
+}
+
+// 3a. A queued delete whose target re-registered must NOT be sent on flush, and
+// must be dropped from the ledger — telling a peer to drop a live rejoined pod
+// would blackhole it.
+func TestFlushSkipsRejoinedMember(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	spy := &delSpy{failPeers: map[string]bool{}}
+	c.notifyDelMember = spy.notify
+
+	// A delete for 9002 is queued for peer 9001, then 9002 comes back as a live
+	// member (addMember does not cancel the queue, isolating the flush guard).
+	c.recordPendingDelete("127.0.0.1:9001", "127.0.0.1:9002")
+	c.addMember(memberInfo("127.0.0.1:9002", "Map"))
+
+	c.flushPendingDeletes("127.0.0.1:9001")
+
+	if spy.sent("127.0.0.1:9001", "127.0.0.1:9002") {
+		t.Fatal("flush told a peer to drop a re-registered (live) member")
+	}
+	if pendingCount(c, "127.0.0.1:9001") != 0 {
+		t.Fatal("stale delete for a re-registered member was not dropped from the ledger")
+	}
+}
+
+// 3b. Re-registering an address cancels any delete still queued for it across
+// all peers (so a later peer heartbeat does not drop the rejoined member).
+func TestCancelPendingDeleteOnReRegister(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	c.notifyDelMember = (&delSpy{failPeers: map[string]bool{}}).notify
+
+	c.recordPendingDelete("127.0.0.1:9001", "127.0.0.1:9002")
+	if pendingCount(c, "127.0.0.1:9001") != 1 {
+		t.Fatal("setup: expected a queued delete")
+	}
+
+	if _, err := c.Register(context.Background(), &clusterpb.RegisterRequest{MemberInfo: memberInfo("127.0.0.1:9002", "Map")}); err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	if pendingCount(c, "127.0.0.1:9001") != 0 {
+		t.Fatal("re-registering 9002 did not cancel the queued delete for it")
+	}
+}
+
+// 4. A partial flush failure re-queues only the failed target; the succeeded
+// one is cleared.
+func TestFlushPartialFailureRequeuesOnlyFailed(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	spy := &pairDelSpy{fail: map[delCall]bool{{"127.0.0.1:9001", "dead:b"}: true}}
+	c.notifyDelMember = spy.notify
+
+	c.recordPendingDelete("127.0.0.1:9001", "dead:a")
+	c.recordPendingDelete("127.0.0.1:9001", "dead:b")
+
+	c.flushPendingDeletes("127.0.0.1:9001")
+
+	if spy.count("127.0.0.1:9001", "dead:a") != 1 || spy.count("127.0.0.1:9001", "dead:b") != 1 {
+		t.Fatalf("both targets should be attempted once: a=%d b=%d",
+			spy.count("127.0.0.1:9001", "dead:a"), spy.count("127.0.0.1:9001", "dead:b"))
+	}
+	if pendingHas(c, "127.0.0.1:9001", "dead:a") {
+		t.Fatal("succeeded delete (dead:a) was wrongly re-queued")
+	}
+	if !pendingHas(c, "127.0.0.1:9001", "dead:b") {
+		t.Fatal("failed delete (dead:b) was not re-queued for retry")
+	}
+}
+
+// 6. A single heartbeat flush is capped so a large backlog cannot pin the
+// handler on synchronous RPCs; the remainder stays queued.
+func TestFlushBatchCapBoundsRetriesPerHeartbeat(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	spy := &delSpy{failPeers: map[string]bool{}}
+	c.notifyDelMember = spy.notify
+
+	const extra = 10
+	for i := 0; i < maxDeleteRetriesPerHeartbeat+extra; i++ {
+		c.recordPendingDelete("127.0.0.1:9001", fmt.Sprintf("dead:%d", i))
+	}
+
+	c.flushPendingDeletes("127.0.0.1:9001")
+
+	if got := spy.count(); got != maxDeleteRetriesPerHeartbeat {
+		t.Fatalf("flush sent %d deletes, want capped at %d", got, maxDeleteRetriesPerHeartbeat)
+	}
+	if got := pendingCount(c, "127.0.0.1:9001"); got != extra {
+		t.Fatalf("expected %d deletes left queued after a capped flush, got %d", extra, got)
+	}
+}
+
+// 4b. The peer-key ledger is bounded; once full, further new peers are dropped
+// (logged, not silent) but existing peers still accept more deletes.
+func TestRecordPendingDeleteBound(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+
+	for i := 0; i < maxPendingDeletePeers+5; i++ {
+		c.recordPendingDelete(fmt.Sprintf("peer:%d", i), "dead:x")
+	}
+	if got := pendingPeerCount(c); got != maxPendingDeletePeers {
+		t.Fatalf("ledger peer count = %d, want capped at %d", got, maxPendingDeletePeers)
+	}
+	// An already-tracked peer can still queue more deletes.
+	c.recordPendingDelete("peer:0", "dead:y")
+	if pendingCount(c, "peer:0") != 2 {
+		t.Fatal("an existing peer should still accept additional queued deletes at the bound")
+	}
+}
+
+// 5. Concurrent heartbeats from the same unknown member must not duplicate the
+// member or its routes (scan+append+route-install are atomic under c.mu).
+func TestConcurrentUnknownHeartbeatsSingleMember(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	c.notifyDelMember = (&delSpy{failPeers: map[string]bool{}}).notify
+
+	const n = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = c.Heartbeat(context.Background(), &clusterpb.HeartbeatRequest{
+				MemberInfo: memberInfo("127.0.0.1:9003", "World"),
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := memberCount(c); got != 1 {
+		t.Fatalf("concurrent unknown heartbeats produced %d members, want 1 (duplicate append)", got)
+	}
+	if got := routableCount(c, "World", "127.0.0.1:9003"); got != 1 {
+		t.Fatalf("World routable %d times for 9003, want exactly 1", got)
+	}
+}
+
+// 8. The received-DelMember path (cluster.delMember) must also drop queued
+// retries destined for the departing peer, not only master Unregister.
+func TestClusterDelMemberDropsPendingDeletes(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+
+	c.recordPendingDelete("127.0.0.1:9001", "127.0.0.1:9002")
+	if pendingCount(c, "127.0.0.1:9001") != 1 {
+		t.Fatal("setup: expected a queued delete for 9001")
+	}
+
+	c.delMember("127.0.0.1:9001")
+
+	if pendingCount(c, "127.0.0.1:9001") != 0 {
+		t.Fatal("cluster.delMember did not drop queued retries for the removed peer")
+	}
+}
+
+// 3c (strengthens issue7 test 3). Unregister must remove the departing member's
+// route from the local table and close its conn pool, not only notify peers.
+func TestUnregisterClearsRouteAndPool(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, rc := newMasterCluster(t)
+	c.notifyDelMember = (&delSpy{failPeers: map[string]bool{}}).notify
+
+	if _, err := c.Register(context.Background(), &clusterpb.RegisterRequest{MemberInfo: memberInfo("127.0.0.1:9002", "Map")}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := rc.createConnPool("127.0.0.1:9002"); err != nil {
+		t.Fatalf("createConnPool: %v", err)
+	}
+	if !routable(c, "Map", "127.0.0.1:9002") {
+		t.Fatal("setup: 9002 should be routable for Map")
+	}
+
+	if _, err := c.Unregister(context.Background(), &clusterpb.UnregisterRequest{ServiceAddr: "127.0.0.1:9002"}); err != nil {
+		t.Fatalf("unregister: %v", err)
+	}
+
+	if routable(c, "Map", "127.0.0.1:9002") {
+		t.Fatal("departing member's route was not purged from the local table")
+	}
+	rc.RLock()
+	_, pooled := rc.pools["127.0.0.1:9002"]
+	rc.RUnlock()
+	if pooled {
+		t.Fatal("departing member's conn pool was not closed/removed")
+	}
+}

--- a/cluster/issue7_review_test.go
+++ b/cluster/issue7_review_test.go
@@ -301,3 +301,74 @@ func TestUnregisterClearsRouteAndPool(t *testing.T) {
 		t.Fatal("departing member's conn pool was not closed/removed")
 	}
 }
+
+// warnCaptureLogger counts Warn calls (matching noopLogger's method set) so a
+// test can assert the bound-overflow warning fires instead of a silent drop.
+type warnCaptureLogger struct {
+	mu    sync.Mutex
+	warns int
+}
+
+func (l *warnCaptureLogger) Warn(...interface{})         { l.mu.Lock(); l.warns++; l.mu.Unlock() }
+func (l *warnCaptureLogger) warnCount() int              { l.mu.Lock(); defer l.mu.Unlock(); return l.warns }
+func (*warnCaptureLogger) Debug(...interface{})          {}
+func (*warnCaptureLogger) Println(...interface{})        {}
+func (*warnCaptureLogger) Infof(string, ...interface{})  {}
+func (*warnCaptureLogger) Error(...interface{})          {}
+func (*warnCaptureLogger) Errorf(string, ...interface{}) {}
+func (*warnCaptureLogger) Fatal(...interface{})          {}
+func (*warnCaptureLogger) Fatalf(string, ...interface{}) {}
+
+// 4c. Overflowing the ledger bound must log a warning, not drop the repair
+// silently (issue #7 review round 1 changed silent-drop -> warn).
+func TestRecordPendingDeleteBoundLogsWarning(t *testing.T) {
+	capLog := &warnCaptureLogger{}
+	log.SetLogger(capLog)
+	defer log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+
+	for i := 0; i < maxPendingDeletePeers; i++ {
+		c.recordPendingDelete(fmt.Sprintf("peer:%d", i), "dead:x")
+	}
+	if capLog.warnCount() != 0 {
+		t.Fatalf("no warning expected before the bound is exceeded, got %d", capLog.warnCount())
+	}
+	// One more distinct peer overflows the bound -> must warn.
+	c.recordPendingDelete("overflow-peer", "dead:x")
+	if capLog.warnCount() == 0 {
+		t.Fatal("recordPendingDelete dropped a retry at the bound without logging a warning")
+	}
+}
+
+// 5b. Stress the unknown-heartbeat vs Unregister interleaving for the same
+// address. Invariant after every round: if the address is not a known member,
+// it must not be routable (a removed member's route must never be reinstalled by
+// a racing heartbeat). Run under -race to exercise the c.mu critical section.
+func TestUnknownHeartbeatRaceUnregisterNoStaleRoute(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	const addr = "127.0.0.1:9007"
+	for iter := 0; iter < 200; iter++ {
+		c, _ := newMasterCluster(t)
+		c.notifyDelMember = (&delSpy{failPeers: map[string]bool{}}).notify
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = c.Heartbeat(context.Background(), &clusterpb.HeartbeatRequest{MemberInfo: memberInfo(addr, "World")})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = c.Unregister(context.Background(), &clusterpb.UnregisterRequest{ServiceAddr: addr})
+		}()
+		close(start)
+		wg.Wait()
+
+		if !c.isKnownAddr(addr) && routable(c, "World", addr) {
+			t.Fatalf("iter %d: %s routable but not a member -> stale route reinstalled after removal", iter, addr)
+		}
+	}
+}

--- a/cluster/issue7_review_test.go
+++ b/cluster/issue7_review_test.go
@@ -372,3 +372,41 @@ func TestUnknownHeartbeatRaceUnregisterNoStaleRoute(t *testing.T) {
 		}
 	}
 }
+
+// 5c. Stress the same-address Register vs Unregister interleaving (a rolling
+// rollover: old pod unregistering while the new pod registers). Invariant after
+// every round: membership and the local route table agree — the address is a
+// known member iff it is routable for its service. The pre-fix non-atomic
+// version could leave a route for a removed member (issue #7, review round 3).
+func TestRegisterUnregisterRaceMembershipRouteConsistent(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	const addr = "127.0.0.1:9008"
+	for iter := 0; iter < 200; iter++ {
+		c, _ := newMasterCluster(t)
+		c.notifyDelMember = (&delSpy{failPeers: map[string]bool{}}).notify
+		// Seed so Unregister has a target and the concurrent Register is a rejoin.
+		if _, err := c.Register(context.Background(), &clusterpb.RegisterRequest{MemberInfo: memberInfo(addr, "Svc")}); err != nil {
+			t.Fatalf("seed register: %v", err)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = c.Register(context.Background(), &clusterpb.RegisterRequest{MemberInfo: memberInfo(addr, "Svc")})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = c.Unregister(context.Background(), &clusterpb.UnregisterRequest{ServiceAddr: addr})
+		}()
+		close(start)
+		wg.Wait()
+
+		if member, routed := c.isKnownAddr(addr), routable(c, "Svc", addr); member != routed {
+			t.Fatalf("iter %d: membership/route diverged: isKnownAddr=%v routable=%v", iter, member, routed)
+		}
+	}
+}

--- a/cluster/issue7_rolling_test.go
+++ b/cluster/issue7_rolling_test.go
@@ -1,0 +1,389 @@
+// Copyright (c) nano Authors. All Rights Reserved.
+//
+// Regression tests for issue #7: "Fix Nano stale member routing during rolling
+// rollouts". They exercise the two root causes and their fixes end-to-end:
+//   1. a failed DelMember notification must be queued and retried (not just
+//      logged) so a peer that briefly missed it stops routing to a dead pod;
+//   2. a same-address rejoin with a changed/shrunk service list must purge the
+//      stale services so they are no longer routable.
+//
+// White-box (package cluster) so the tests can read unexported fields/methods
+// and override the notify seam. They are written against the cluster.go
+// CONTRACT (pendingDeletes / notifyDelMember and the pending-delete helpers);
+// no production code is implemented here.
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lonng/nano/cluster/clusterpb"
+	"github.com/lonng/nano/internal/log"
+)
+
+// delCall records a single notifyDelMember invocation.
+type delCall struct{ peer, deleted string }
+
+// delSpy is a recording stub for the cluster.notifyDelMember seam. It captures
+// every (peer, deleted) pair and can be configured to fail for specific peers
+// so the pending-delete queue/retry path can be driven deterministically.
+type delSpy struct {
+	mu        sync.Mutex
+	calls     []delCall
+	failPeers map[string]bool // peer -> notify returns error
+}
+
+func (s *delSpy) notify(peer, deleted string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, delCall{peer, deleted})
+	if s.failPeers[peer] {
+		return errors.New("unreachable")
+	}
+	return nil
+}
+
+func (s *delSpy) sent(peer, deleted string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, c := range s.calls {
+		if c.peer == peer && c.deleted == deleted {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *delSpy) sentToPeer(peer string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, c := range s.calls {
+		if c.peer == peer {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *delSpy) count() int { s.mu.Lock(); defer s.mu.Unlock(); return len(s.calls) }
+
+// countPair returns how many times the exact (peer, deleted) pair was notified.
+// Unlike sent, it lets a test distinguish a retry from the original call.
+func (s *delSpy) countPair(peer, deleted string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, c := range s.calls {
+		if c.peer == peer && c.deleted == deleted {
+			n++
+		}
+	}
+	return n
+}
+
+// pendingCount reads the size of the pending-delete ledger for peer under the
+// cluster lock.
+func pendingCount(c *cluster, peer string) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.pendingDeletes[peer])
+}
+
+// memberCount returns the number of registered members under the cluster lock.
+func memberCount(c *cluster) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.members)
+}
+
+// lastHeartbeat returns the recorded lastHeartbeatAt for addr (and whether the
+// member exists) under the cluster lock.
+func lastHeartbeat(c *cluster, addr string) (time.Time, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, m := range c.members {
+		if m.memberInfo.ServiceAddr == addr {
+			return m.lastHeartbeatAt, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// routableCount reports how many times addr is selectable for service in the
+// handler's routing table (a copy is returned by findMembers).
+func routableCount(c *cluster, service, addr string) int {
+	n := 0
+	for _, m := range c.currentNode.handler.findMembers(service) {
+		if m.ServiceAddr == addr {
+			n++
+		}
+	}
+	return n
+}
+
+// routable reports whether addr is selectable for service at all.
+func routable(c *cluster, service, addr string) bool {
+	return routableCount(c, service, addr) > 0
+}
+
+//  1. A new pod must register successfully even when an existing peer is
+//     unreachable: the join is local-first and the new member becomes routable
+//     regardless of best-effort peer fan-out failures (fixes 1 & 2).
+func TestNewPodRegisterSucceedsWhenPeerUnreachableIssue7(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, rc := newMasterCluster(t)
+	c.addMember(memberInfo("127.0.0.1:9001", "peer"))
+	rc.closePool() // every getConnPool now errors -> peer fan-out must be best-effort
+
+	resp, err := c.Register(context.Background(), &clusterpb.RegisterRequest{
+		MemberInfo: memberInfo("127.0.0.1:9002", "Map"),
+	})
+	if err != nil {
+		t.Fatalf("Register aborted on an unreachable peer (issue #7 fix 1): %v", err)
+	}
+	if resp == nil {
+		t.Fatal("nil register response")
+	}
+	if !c.isKnownAddr("127.0.0.1:9002") {
+		t.Fatal("new member not added to the local registry despite peer fan-out failure")
+	}
+	if !routable(c, "Map", "127.0.0.1:9002") {
+		t.Fatal("new member 127.0.0.1:9002 is not routable for service Map after register")
+	}
+}
+
+//  2. A same-address rejoin that drops a service must leave no stale route for
+//     that service under the old address (fixes 2 & 7).
+func TestSameAddrRejoinRemovesOldServiceRoutes(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+
+	if _, err := c.Register(context.Background(), &clusterpb.RegisterRequest{
+		MemberInfo: memberInfo("127.0.0.1:9001", "Map", "Chat"),
+	}); err != nil {
+		t.Fatalf("initial Register failed: %v", err)
+	}
+	if !routable(c, "Map", "127.0.0.1:9001") {
+		t.Fatal("127.0.0.1:9001 not routable for Map after initial register")
+	}
+	if !routable(c, "Chat", "127.0.0.1:9001") {
+		t.Fatal("127.0.0.1:9001 not routable for Chat after initial register")
+	}
+
+	// Rejoin with the SAME address but only the Map service.
+	if _, err := c.Register(context.Background(), &clusterpb.RegisterRequest{
+		MemberInfo: memberInfo("127.0.0.1:9001", "Map"),
+	}); err != nil {
+		t.Fatalf("rejoin Register failed: %v", err)
+	}
+	if got := routableCount(c, "Map", "127.0.0.1:9001"); got != 1 {
+		t.Fatalf("expected 127.0.0.1:9001 routable for Map exactly once after rejoin, got %d", got)
+	}
+	if routable(c, "Chat", "127.0.0.1:9001") {
+		t.Fatal("stale Chat route for 127.0.0.1:9001 survived a rejoin that dropped the service")
+	}
+}
+
+//  3. Unregister must tell remaining peers to drop the departing member (via the
+//     notify seam) without notifying the departing member itself, and clear it
+//     from the local registry (fix 3).
+func TestUnregisterBroadcastsDeleteAndClearsRoutes(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	spy := &delSpy{failPeers: map[string]bool{}}
+	c.notifyDelMember = spy.notify
+
+	c.addMember(memberInfo("127.0.0.1:9002", "Map"))  // the departing member
+	c.addMember(memberInfo("127.0.0.1:9001", "Chat")) // a live peer to notify
+
+	if _, err := c.Unregister(context.Background(), &clusterpb.UnregisterRequest{
+		ServiceAddr: "127.0.0.1:9002",
+	}); err != nil {
+		t.Fatalf("Unregister returned error: %v", err)
+	}
+	if !spy.sent("127.0.0.1:9001", "127.0.0.1:9002") {
+		t.Fatal("peer 127.0.0.1:9001 was not told to drop departing member 127.0.0.1:9002")
+	}
+	if spy.sentToPeer("127.0.0.1:9002") {
+		t.Fatal("departing member 127.0.0.1:9002 must not be notified about its own removal")
+	}
+	if c.isKnownAddr("127.0.0.1:9002") {
+		t.Fatal("departing member 127.0.0.1:9002 still present in the registry after Unregister")
+	}
+}
+
+//  4. The headline fix: a DelMember notification that fails is queued and then
+//     retried (and cleared) when the recipient peer next heartbeats (fix 4).
+func TestMissedDeleteQueuedAndRetriedOnHeartbeat(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	spy := &delSpy{failPeers: map[string]bool{"127.0.0.1:9001": true}}
+	c.notifyDelMember = spy.notify
+
+	c.addMember(memberInfo("127.0.0.1:9001", "Chat")) // peer that will miss the delete
+	c.addMember(memberInfo("127.0.0.1:9002", "Map"))  // the departing member
+
+	if _, err := c.Unregister(context.Background(), &clusterpb.UnregisterRequest{
+		ServiceAddr: "127.0.0.1:9002",
+	}); err != nil {
+		t.Fatalf("Unregister returned error: %v", err)
+	}
+	if got := pendingCount(c, "127.0.0.1:9001"); got != 1 {
+		t.Fatalf("expected 1 pending delete queued for unreachable peer 127.0.0.1:9001, got %d", got)
+	}
+
+	// Peer becomes reachable again and heartbeats -> queued delete is retried.
+	// notify records the call before returning the initial failure, so a bare
+	// "was it ever sent" check is already true here. Capture the per-pair count
+	// and require it to strictly increase so the assertion only passes when the
+	// heartbeat actually re-issues the notification (not merely clears the
+	// ledger).
+	before := spy.countPair("127.0.0.1:9001", "127.0.0.1:9002")
+	spy.failPeers["127.0.0.1:9001"] = false
+	if _, err := c.Heartbeat(context.Background(), &clusterpb.HeartbeatRequest{
+		MemberInfo: memberInfo("127.0.0.1:9001", "Chat"),
+	}); err != nil {
+		t.Fatalf("Heartbeat returned error: %v", err)
+	}
+	if after := spy.countPair("127.0.0.1:9001", "127.0.0.1:9002"); after <= before {
+		t.Fatalf("queued delete for 127.0.0.1:9002 was not retried to 127.0.0.1:9001 on heartbeat: notify count stayed at %d", after)
+	}
+	if got := pendingCount(c, "127.0.0.1:9001"); got != 0 {
+		t.Fatalf("expected pending deletes cleared after successful retry, got %d", got)
+	}
+}
+
+//  5. A synchronous UnregisterCallback that re-registers the same address must
+//     not deadlock Unregister, and the member must end up re-registered (fix 6).
+func TestSyncUnregisterCallbackReregistersWithoutDeadlock(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	c.currentNode.UnregisterCallback = func(_ Member, reReg func()) { reReg() }
+
+	c.addMember(memberInfo("127.0.0.1:9002", "Map"))
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = c.Unregister(context.Background(), &clusterpb.UnregisterRequest{
+			ServiceAddr: "127.0.0.1:9002",
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Unregister deadlocked on synchronous re-register callback")
+	}
+	if !c.isKnownAddr("127.0.0.1:9002") {
+		t.Fatal("synchronous callback did not re-register 127.0.0.1:9002")
+	}
+}
+
+//  6. A heartbeat from a known, stable member only refreshes its timestamp: no
+//     broadcast and no route churn (fix 5).
+func TestStableHeartbeatNoBroadcastOrRouteChurn(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	spy := &delSpy{failPeers: map[string]bool{}}
+	c.notifyDelMember = spy.notify
+
+	if _, err := c.Register(context.Background(), &clusterpb.RegisterRequest{
+		MemberInfo: memberInfo("127.0.0.1:9001", "Map"),
+	}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	routesBefore := len(c.currentNode.handler.findMembers("Map"))
+	membersBefore := memberCount(c)
+	hbBefore, ok := lastHeartbeat(c, "127.0.0.1:9001")
+	if !ok {
+		t.Fatal("member 127.0.0.1:9001 missing after register")
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	if _, err := c.Heartbeat(context.Background(), &clusterpb.HeartbeatRequest{
+		MemberInfo: memberInfo("127.0.0.1:9001", "Map"),
+	}); err != nil {
+		t.Fatalf("Heartbeat returned error: %v", err)
+	}
+
+	if got := spy.count(); got != 0 {
+		t.Fatalf("stable heartbeat must not broadcast any delete, got %d notify calls", got)
+	}
+	if got := len(c.currentNode.handler.findMembers("Map")); got != routesBefore {
+		t.Fatalf("route count for Map churned on stable heartbeat: before=%d after=%d", routesBefore, got)
+	}
+	if routableCount(c, "Map", "127.0.0.1:9001") != 1 {
+		t.Fatal("127.0.0.1:9001 should remain routable for Map exactly once after stable heartbeat")
+	}
+	if got := memberCount(c); got != membersBefore {
+		t.Fatalf("member count changed on stable heartbeat: before=%d after=%d", membersBefore, got)
+	}
+	hbAfter, ok := lastHeartbeat(c, "127.0.0.1:9001")
+	if !ok {
+		t.Fatal("member 127.0.0.1:9001 missing after heartbeat")
+	}
+	if !hbAfter.After(hbBefore) {
+		t.Fatalf("lastHeartbeatAt did not advance on heartbeat: before=%s after=%s", hbBefore, hbAfter)
+	}
+}
+
+//  7. After a master restart it no longer knows a live member; a heartbeat from
+//     that unknown member must re-learn the member and its services (fix 7).
+func TestMasterRestartHeartbeatRelearnsMemberServices(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+
+	// 127.0.0.1:9003 was never registered with this (restarted) master.
+	if _, err := c.Heartbeat(context.Background(), &clusterpb.HeartbeatRequest{
+		MemberInfo: memberInfo("127.0.0.1:9003", "World"),
+	}); err != nil {
+		t.Fatalf("Heartbeat returned error: %v", err)
+	}
+	if !c.isKnownAddr("127.0.0.1:9003") {
+		t.Fatal("unknown-member heartbeat did not re-learn 127.0.0.1:9003")
+	}
+	if !routable(c, "World", "127.0.0.1:9003") {
+		t.Fatal("unknown-member heartbeat did not re-learn service World for 127.0.0.1:9003")
+	}
+}
+
+//  8. When a peer that still has queued retries itself unregisters, those
+//     retries must be dropped so they are never sent to a gone peer (fixes 4 & 8).
+func TestUnregisterDropsPendingDeletesForDepartingPeer(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	spy := &delSpy{failPeers: map[string]bool{"127.0.0.1:9001": true}}
+	c.notifyDelMember = spy.notify
+
+	c.addMember(memberInfo("127.0.0.1:9001", "Chat")) // peer whose delete will be queued
+	c.addMember(memberInfo("127.0.0.1:9002", "Map"))  // the first departing member
+
+	if _, err := c.Unregister(context.Background(), &clusterpb.UnregisterRequest{
+		ServiceAddr: "127.0.0.1:9002",
+	}); err != nil {
+		t.Fatalf("Unregister 9002 returned error: %v", err)
+	}
+	if got := pendingCount(c, "127.0.0.1:9001"); got != 1 {
+		t.Fatalf("expected 1 queued delete for unreachable peer 127.0.0.1:9001, got %d", got)
+	}
+
+	// The peer itself now leaves -> its queued retries must be discarded.
+	if _, err := c.Unregister(context.Background(), &clusterpb.UnregisterRequest{
+		ServiceAddr: "127.0.0.1:9001",
+	}); err != nil {
+		t.Fatalf("Unregister 9001 returned error: %v", err)
+	}
+	if got := pendingCount(c, "127.0.0.1:9001"); got != 0 {
+		t.Fatalf("queued retries for departed peer 127.0.0.1:9001 were not dropped, got %d", got)
+	}
+	if c.isKnownAddr("127.0.0.1:9001") {
+		t.Fatal("departed peer 127.0.0.1:9001 still present in the registry")
+	}
+}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -1136,7 +1136,10 @@ func (n *Node) NewMember(_ context.Context, req *clusterpb.NewMemberRequest) (*c
 	if req == nil || req.MemberInfo == nil || req.MemberInfo.ServiceAddr == "" {
 		return nil, ErrInvalidRegisterReq
 	}
-	n.handler.addRemoteService(req.MemberInfo)
+	// Use replaceRemoteService (not addRemoteService) so a same-address rejoin
+	// that dropped a service purges the stale route on this peer too; an additive
+	// add would leave the dropped service routable here (issue #7, fix 2/7).
+	n.handler.replaceRemoteService(req.MemberInfo)
 	n.cluster.addMember(req.MemberInfo)
 	return &clusterpb.NewMemberResponse{}, nil
 }

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -48,8 +48,8 @@ import (
 	"github.com/lonng/nano/metrics"
 	"github.com/lonng/nano/pipeline"
 	"github.com/lonng/nano/scheduler"
-	"github.com/lonng/nano/session"
 	nanojson "github.com/lonng/nano/serialize/json"
+	"github.com/lonng/nano/session"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/valyala/fasthttp"
 	"google.golang.org/grpc"
@@ -728,6 +728,7 @@ func (n *Node) listenAndServeWS(ctx *fasthttp.RequestCtx) {
 		return
 	}
 }
+
 // (removed dead listenAndServeWSTLS: it had no caller, routed WS through the
 // global http.DefaultServeMux, and called log.Fatal on a bind error. TLS is now
 // served by listenAndServe via fasthttp ServeTLS (M30).)
@@ -978,9 +979,9 @@ func (n *Node) findOrCreateSession(sid, clientUid int64, gateAddr string, client
 		return nil, err
 	}
 	ac := &acceptor{
-		sid:        sid,
-		gateClient: clusterpb.NewMemberClient(conns.Get()),
-		rpcHandler: n.handler.remoteProcess,
+		sid:         sid,
+		gateClient:  clusterpb.NewMemberClient(conns.Get()),
+		rpcHandler:  n.handler.remoteProcess,
 		gateAddr:    gateAddr,
 		jsonPayload: jsonPayload,
 	}
@@ -1136,11 +1137,14 @@ func (n *Node) NewMember(_ context.Context, req *clusterpb.NewMemberRequest) (*c
 	if req == nil || req.MemberInfo == nil || req.MemberInfo.ServiceAddr == "" {
 		return nil, ErrInvalidRegisterReq
 	}
-	// Use replaceRemoteService (not addRemoteService) so a same-address rejoin
-	// that dropped a service purges the stale route on this peer too; an additive
-	// add would leave the dropped service routable here (issue #7, fix 2/7).
+	// Update membership and install routes under one c.mu critical section so a
+	// concurrent same-address DelMember cannot interleave a route/member split on
+	// this peer (issue #7, review round 4). replaceRemoteService also drops stale
+	// services on a same-address rejoin (fix 2/7). c.mu -> h.mu order is safe.
+	n.cluster.mu.Lock()
+	n.cluster.addMemberLocked(req.MemberInfo)
 	n.handler.replaceRemoteService(req.MemberInfo)
-	n.cluster.addMember(req.MemberInfo)
+	n.cluster.mu.Unlock()
 	return &clusterpb.NewMemberResponse{}, nil
 }
 
@@ -1149,8 +1153,15 @@ func (n *Node) DelMember(_ context.Context, req *clusterpb.DelMemberRequest) (*c
 		return nil, ErrInvalidRegisterReq
 	}
 	log.Println("[Node] DelMember member", req.String())
+	// Remove routes and membership under one c.mu critical section so a
+	// concurrent same-address NewMember cannot interleave a route/member split on
+	// this peer (issue #7, review round 4). Pool teardown / pending-delete drop
+	// stay outside the lock.
+	n.cluster.mu.Lock()
 	n.handler.delMember(req.ServiceAddr)
-	n.cluster.delMember(req.ServiceAddr)
+	n.cluster.removeMemberLocked(req.ServiceAddr)
+	n.cluster.mu.Unlock()
+	n.cluster.releaseDepartedPeer(req.ServiceAddr)
 	// Purge any acceptor sessions homed on the departed gate so they don't leak
 	// in n.sessions when the gate vanishes before sending per-session
 	// SessionClosed RPCs (H24).
@@ -1315,6 +1326,7 @@ func (n *Node) authUnaryInterceptor(
 	}
 	return handler(ctx, req)
 }
+
 // runGRPCServer serves the gRPC listener. A post-startup Serve error is logged
 // rather than escalated to log.Fatalf, which would call os.Exit from this
 // background goroutine and bypass node/component shutdown.


### PR DESCRIPTION
## Summary

Fixes stale member routing during rolling rollouts (closes #7). The downstream incident — `MapService.GetMyCastle` staying pending while master/gateway route tables still referenced dead pod IPs — had two root causes that survived until a process restart:

1. **Missed `DelMember` was never retried.** `Unregister` broadcast the delete best-effort and only *logged* failures, so a peer that was briefly unreachable kept routing to the unregistered pod **indefinitely**.
2. **Same-address rejoin left stale services routable.** `addRemoteService` only refreshes the services a member still advertises, so a rejoin that *dropped* a service left the old route selectable under the same address.

## What changed (`cluster/`)

- **Missed-delete repair ledger (fix 4).** New `pendingDeletes` map (recipient peer → set of member addrs it must still drop), guarded by the existing `cluster.mu`. A failed `DelMember` in `Unregister` is now **queued** via `recordPendingDelete` and **retried** by `flushPendingDeletes` on that peer's **next heartbeat**. Gated on pending work, so a stable cluster does zero extra work.
- **Clean route replacement on rejoin (fixes 2 & 7).** New `LocalHandler.replaceRemoteService` atomically purges **every** route entry for a `ServiceAddr` and installs the member's current service list. Wired into `Register` and the unknown-member `Heartbeat` path.
- **Liveness/consistency hardening.** A (re)registering node calls `cancelPendingDelete` (don't later teach peers to drop a member that came back); a departing peer's queued retries are dropped via `dropPendingDeletesForPeer`.
- **Steady-state heartbeat stays O(1) (fix 5).** A heartbeat from a *known* member only refreshes `lastHeartbeatAt` (no route sync, no broadcast) and flushes that peer's pending deletes if any.
- **Test seam.** `notifyDelMember` is an injectable field (default `sendDelMember`) so the fan-out is deterministically testable without a live gRPC peer.

Fixes **1 / 3 / 5 / 8** from the issue already landed in `v1.2.0` (PR #6: best-effort register/unregister, conn-pool close on departure, cheap stable heartbeat, SSE/session cleanup). This PR adds the remaining **2 / 4 / 6 / 7** and **regression tests for all eight** behaviors.

## Tests — `cluster/issue7_rolling_test.go` (8)

| Test | Issue item |
|---|---|
| `TestNewPodRegisterSucceedsWhenPeerUnreachableIssue7` | 1 (+2) — new member routable despite unreachable peer |
| `TestSameAddrRejoinRemovesOldServiceRoutes` | 2/7 — dropped service no longer routable after rejoin |
| `TestUnregisterBroadcastsDeleteAndClearsRoutes` | 3 — peers told to drop; departing not notified; registry cleared |
| `TestMissedDeleteQueuedAndRetriedOnHeartbeat` | 4 — failed delete queued, **re-issued** on heartbeat, then cleared |
| `TestSyncUnregisterCallbackReregistersWithoutDeadlock` | 6 — synchronous re-register callback does not deadlock |
| `TestStableHeartbeatNoBroadcastOrRouteChurn` | 5 — stable heartbeat: 0 broadcasts, no route churn, timestamp advances |
| `TestMasterRestartHeartbeatRelearnsMemberServices` | 7 — unknown-member heartbeat re-learns services |
| `TestUnregisterDropsPendingDeletesForDepartingPeer` | 4/8 — a departing peer's queued retries are dropped |

## Verification

```
go build ./...                                   # ok
go test -race -skip 'TestNode' ./cluster/... ./scheduler/... ./session/... \
        ./internal/... . ./component/... ./pipeline/... ./service/... ./metrics/...   # all ok, 0 data races
go vet ./...                                     # only the 2 pre-existing findings (interface.go:111, examples/cluster/main.go:152)
```

`TestNode*` (legacy gocheck in-process handshake) is a pre-existing hang, excluded via `-skip`, not modified.

## Downstream

After merge + tag, Xlords bumps its `replace github.com/lonng/nano => github.com/qtnx/nano` pin from `v1.1.54` to the new tag.
