### PR TITLE
fix(cluster): make the master's local route updates atomic with membership

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -131,10 +131,15 @@ func (c *cluster) Register(_ context.Context, req *clusterpb.RegisterRequest) (*
 		membershipEpoch:   membershipEpoch,
 		membershipVersion: c.membershipVersion,
 	})
-	c.mu.Unlock()
-
+	// Update the master's own route table while still holding c.mu, atomically
+	// with the membership append. The master does not self-reconcile its route
+	// cache (only peers do, via heartbeat responses), so doing this after unlock
+	// let a concurrent same-address Unregister interleave and leave the master
+	// routing to a removed member (issue #7 follow-up). c.mu -> h.mu is the global
+	// order; handler route methods take only h.mu and do no network I/O.
 	c.currentNode.handler.delMember(req.MemberInfo.ServiceAddr)
 	c.currentNode.handler.addRemoteService(req.MemberInfo)
+	c.mu.Unlock()
 
 	log.Println("New peer register to cluster", req.MemberInfo.ServiceAddr)
 
@@ -208,6 +213,15 @@ func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest
 	} else {
 		c.members = append(c.members[:index], c.members[index+1:]...)
 	}
+	// Remove from the master's own route table while still holding c.mu,
+	// atomically with the membership removal (the master does not self-reconcile
+	// its route cache), so a concurrent same-address Register cannot leave the
+	// master routing to a removed member (issue #7 follow-up). removeRemoteMember
+	// below repeats handler.delMember (a harmless no-op) plus the session/pool
+	// teardown that must stay outside the lock.
+	if c.currentNode != nil {
+		c.currentNode.handler.delMember(req.ServiceAddr)
+	}
 	c.mu.Unlock()
 
 	if c.currentNode != nil {
@@ -262,7 +276,6 @@ func (c *cluster) Heartbeat(_ context.Context, req *clusterpb.HeartbeatRequest) 
 	}
 	log.Println("Receive Heartbeat from: ", req.MemberInfo.Label)
 
-	var addedMember *clusterpb.MemberInfo
 	c.mu.Lock()
 	membershipEpoch := c.ensureMembershipEpochLocked()
 
@@ -286,7 +299,7 @@ func (c *cluster) Heartbeat(_ context.Context, req *clusterpb.HeartbeatRequest) 
 		c.membershipVersion++
 		m.membershipVersion = c.membershipVersion
 		c.clearRemovedMemberLocked(req.GetMemberInfo().GetServiceAddr())
-		addedMember = req.MemberInfo
+		c.currentNode.handler.addRemoteService(req.MemberInfo)
 		log.Println("Heartbeat peer register to cluster", req.MemberInfo.ServiceAddr)
 	}
 
@@ -320,9 +333,6 @@ func (c *cluster) Heartbeat(_ context.Context, req *clusterpb.HeartbeatRequest) 
 	}
 	c.mu.Unlock()
 
-	if addedMember != nil {
-		c.currentNode.handler.addRemoteService(addedMember)
-	}
 	return resp, nil
 }
 


### PR DESCRIPTION
## Summary

Small **defensive hardening** on top of #8's membership reconciliation. Makes the **master's own** route-table updates atomic with its `c.members` updates in `Register`, `Unregister` and the unknown-member `Heartbeat` path.

## Background

#8 fixed stale member routing (issue #7) with version/epoch reconciliation: **peers** self-heal their route cache from the master's heartbeat responses (`reconcileMembersSnapshot`), plus `removedMembers` tombstones and epoch reset. That handles the broad cross-node cases well.

The **master**, however, never reconciles its *own* route table — it mutates it directly in `Register`/`Unregister`/`Heartbeat`, and those `handler.delMember` / `handler.addRemoteService` calls ran **outside** the `c.mu` critical section that updates `c.members`:

```go
// Register (before)
c.members = append(c.members, ...)
c.mu.Unlock()
c.currentNode.handler.delMember(addr)        // route update OUTSIDE c.mu
c.currentNode.handler.addRemoteService(req.MemberInfo)
```

A same-address rollover (old pod's `Unregister` racing the new pod's `Register`) could interleave so the master's route cache ends up disagreeing with `c.members` (a route for a removed member, or a registered member left unroutable). Since the master has no reconcile path, that skew **persists** — the shape of the original incident ("master/gateway route tables referenced dead pod IPs").

## Change

Move the master's local route-table mutations **inside** the same `c.mu` section as the membership change, in all three paths. Lock order stays `c.mu -> h.mu` (handler route methods take only `h.mu` and do no network I/O); RPC fan-out, pool teardown and session cleanup remain **outside** the lock. Peer receive paths (`Node.NewMember`/`Node.DelMember`) are intentionally unchanged — they self-heal via reconcile.

`cluster/cluster.go`: +17 / −7.

## Verification & honest caveat

- `go build ./...` ✓; `go test -race ./cluster` (incl. #8's reconcile/membership suite) ✓.
- **No deterministic regression test.** The divergence requires a goroutine to be preempted in the ~1–2 statement gap between the unlock and the route call while a concurrent same-address op completes — **unreproducible in 1000 `-race` iterations**. A race test for it passed with *and* without the fix, i.e. it would be vacuous, so it was removed rather than shipped as false assurance. This change is justified by **code review** (the route ops now occur inside the existing membership critical section) and is strictly a safety tightening with no runtime cost (reuses the lock already held).

Reviewers who consider the window negligible can reasonably decline this; it's filed as low-risk hardening, not a fix for an observed failure.
