### PR TITLE
fix(codec): allow large response packets

### DIFF
--- a/internal/codec/codec.go
+++ b/internal/codec/codec.go
@@ -29,8 +29,10 @@ import (
 
 // Codec constants.
 const (
-	HeadLength    = 4
-	MaxPacketSize = 64 * 1024
+	HeadLength = 4
+	// 512KB leaves headroom for large response payloads while staying well below
+	// the protocol's 3-byte length ceiling (0xFFFFFF, roughly 16MB).
+	MaxPacketSize = 512 * 1024
 )
 
 // ErrPacketSizeExcced is the error used for encode/decode.

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -166,6 +166,39 @@ func TestEncodeMaxPacketSize(t *testing.T) {
 	}
 }
 
+func TestEncodeDecodeAllowsLargeResponsePayload(t *testing.T) {
+	if MaxPacketSize != 512*1024 {
+		t.Fatalf("MaxPacketSize = %d, want 512KB cap for large responses", MaxPacketSize)
+	}
+
+	payload := make([]byte, 88*1024)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	encoded, err := Encode(Data, payload)
+	if err != nil {
+		t.Fatalf("Encode 88KB response payload error = %v, want nil", err)
+	}
+
+	packets, err := NewDecoder().Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode 88KB response packet error = %v, want nil", err)
+	}
+	if len(packets) != 1 {
+		t.Fatalf("Decode packet count = %d, want 1", len(packets))
+	}
+	if packets[0].Type != Data {
+		t.Fatalf("Decode packet type = %v, want %v", packets[0].Type, Data)
+	}
+	if packets[0].Length != len(payload) {
+		t.Fatalf("Decode packet length = %d, want %d", packets[0].Length, len(payload))
+	}
+	if !reflect.DeepEqual(packets[0].Data, payload) {
+		t.Fatal("Decode packet data changed for 88KB response payload")
+	}
+}
+
 // TestDecoderResetAfterError covers L8: after a forward() error the decoder must
 // not retain stale frame state (oversized size / consumed header), so a reused
 // decoder can still parse a subsequent valid packet.


### PR DESCRIPTION
## Context

`v1.2.x` added an encode-side packet size guard that reused `MaxPacketSize = 64KB`. That cap is too small for legitimate large response payloads, for example catalog responses around 88KB. The result is `codec.Encode(packet.Data, payload)` returning `ErrPacketSizeExcced`, so the gateway never writes the WebSocket response.

The protocol length field is 3 bytes, so the wire ceiling is roughly 16MB. This PR keeps a conservative application cap but raises it enough for current large responses.

## Changes

- Raise `internal/codec.MaxPacketSize` from `64KB` to `512KB`.
- Add a regression test that encodes and decodes an 88KB `Data` packet successfully.
- Keep existing oversized-payload guard behavior: `MaxPacketSize + 1` still returns `ErrPacketSizeExcced`.

## Verification

- Watched the new regression test fail before the fix:
  - `go test ./internal/codec -run TestEncodeDecodeAllowsLargeResponsePayload -count=1`
  - failed with `Encode 88KB response payload error = codec: packet size exceed`
- `go test ./internal/codec -run 'TestEncodeDecodeAllowsLargeResponsePayload|TestEncodeMaxPacketSize|TestDecodeMalformedPacketsReturnExpectedErrors|TestDecoderResetAfterError' -count=1` — pass
- `go test ./internal/codec/... -count=1` — pass
- `go test ./internal/message/... ./cluster -run 'TestEncode|TestDecode|TestPack|Test.*Codec|Test.*HTTP|Test.*SSE|Test.*Response|Test.*Packet|TestHandleSSE|TestNodeHTTP|TestNodeSafety|TestReconcile' -count=1` — pass
- `go test ./... -count=1 -timeout=2m` — pass
- `go test -race ./internal/codec -count=1` — pass
- `git diff --check` — pass

## Risks / Rollback

- This allows individual codec frames up to 512KB instead of 64KB, increasing the maximum accepted allocation for a single frame. It remains far below the 3-byte protocol ceiling and avoids opening the full ~16MB range.
- Rollback is reverting this commit, but that would restore the large-response WebSocket drop for payloads over 64KB.
