### PR TITLE
feat(scheduler): add concurrent request routes

### DIFF
--- a/cluster/acceptor.go
+++ b/cluster/acceptor.go
@@ -3,23 +3,26 @@ package cluster
 import (
 	"context"
 	"net"
-
-	"github.com/lonng/nano/internal/log"
+	"sync"
+	"sync/atomic"
 
 	"github.com/lonng/nano/cluster/clusterpb"
+	"github.com/lonng/nano/internal/log"
 	"github.com/lonng/nano/internal/message"
 	"github.com/lonng/nano/mock"
 	"github.com/lonng/nano/session"
 )
 
 type acceptor struct {
-	sid        int64
-	gateClient clusterpb.MemberClient
-	session    *session.Session
-	lastMid    uint64
-	rpcHandler rpcHandler
-	gateAddr    string
-	jsonPayload bool
+	sid                     int64
+	gateClient              clusterpb.MemberClient
+	session                 *session.Session
+	lastMid                 uint64
+	rpcHandler              rpcHandler
+	gateAddr                string
+	jsonPayload             bool
+	reqMids                 sync.Map
+	strictRequestMidBinding atomic.Bool
 }
 
 // Push implements the session.NetworkEntity interface
@@ -72,16 +75,44 @@ func (a *acceptor) RPCWithResponse(route string, v interface{}) ([]byte, error) 
 
 // LastMid implements the session.NetworkEntity interface
 func (a *acceptor) LastMid() uint64 {
-	return a.lastMid
+	if raw, ok := a.reqMids.Load(goID()); ok {
+		return raw.(uint64)
+	}
+	return atomic.LoadUint64(&a.lastMid)
+}
+
+func (a *acceptor) setLastMid(mid uint64) {
+	atomic.StoreUint64(&a.lastMid, mid)
+}
+
+func (a *acceptor) setStrictRequestMidBinding(enabled bool) {
+	a.strictRequestMidBinding.Store(enabled)
+}
+
+func (a *acceptor) runWithRequestMid(mid uint64, fn func()) {
+	a.setLastMid(mid)
+	gid := goID()
+	a.reqMids.Store(gid, mid)
+	defer a.reqMids.Delete(gid)
+	fn()
 }
 
 // Response implements the session.NetworkEntity interface
 func (a *acceptor) Response(v interface{}) error {
-	return a.ResponseMid(a.lastMid, v)
+	if raw, ok := a.reqMids.Load(goID()); ok {
+		return a.ResponseMid(raw.(uint64), v)
+	}
+	if a.strictRequestMidBinding.Load() {
+		return errNoRequestBound
+	}
+	return a.ResponseMid(atomic.LoadUint64(&a.lastMid), v)
 }
 
 // ResponseMid implements the session.NetworkEntity interface
 func (a *acceptor) ResponseMid(mid uint64, v interface{}) error {
+	if mid <= 0 {
+		return ErrSessionOnNotify
+	}
 
 	log.Debugf("[Acceptor] ResponseMid: %d", mid)
 	// TODO: buffer

--- a/cluster/agent.go
+++ b/cluster/agent.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -55,15 +56,17 @@ type (
 	// Agent corresponding a user, used for store raw conn information
 	agent struct {
 		// regular agent member
-		session  *session.Session    // session
-		conn     net.Conn            // low-level conn fd
-		lastMid  uint64              // last message id
-		state    int32               // current agent state
-		chDie    chan struct{}       // wait for close
-		chSend   chan pendingMessage // push message queue
-		lastAt   int64               // last heartbeat unix time stamp
-		decoder  *codec.Decoder      // binary decoder
-		pipeline pipeline.Pipeline
+		session                 *session.Session    // session
+		conn                    net.Conn            // low-level conn fd
+		lastMid                 uint64              // last message id; access atomically
+		state                   int32               // current agent state
+		chDie                   chan struct{}       // wait for close
+		chSend                  chan pendingMessage // push message queue
+		lastAt                  int64               // last heartbeat unix time stamp
+		decoder                 *codec.Decoder      // binary decoder
+		pipeline                pipeline.Pipeline
+		reqMids                 sync.Map // goroutine id -> in-flight request mid
+		strictRequestMidBinding atomic.Bool
 
 		rpcHandler rpcHandler
 		srv        reflect.Value // cached session reflect.Value
@@ -134,9 +137,27 @@ func (a *agent) send(m pendingMessage) (err error) {
 	}
 }
 
-// LastMid implements the session.NetworkEntity interface
 func (a *agent) LastMid() uint64 {
-	return a.lastMid
+	if raw, ok := a.reqMids.Load(goID()); ok {
+		return raw.(uint64)
+	}
+	return atomic.LoadUint64(&a.lastMid)
+}
+
+func (a *agent) setLastMid(mid uint64) {
+	atomic.StoreUint64(&a.lastMid, mid)
+}
+
+func (a *agent) setStrictRequestMidBinding(enabled bool) {
+	a.strictRequestMidBinding.Store(enabled)
+}
+
+func (a *agent) runWithRequestMid(mid uint64, fn func()) {
+	a.setLastMid(mid)
+	gid := goID()
+	a.reqMids.Store(gid, mid)
+	defer a.reqMids.Delete(gid)
+	fn()
 }
 
 // Push, implementation for session.NetworkEntity interface
@@ -187,7 +208,13 @@ func (a *agent) RPC(route string, v interface{}) error {
 // Response, implementation for session.NetworkEntity interface
 // Response message to session
 func (a *agent) Response(v interface{}) error {
-	return a.ResponseMid(a.lastMid, v)
+	if raw, ok := a.reqMids.Load(goID()); ok {
+		return a.ResponseMid(raw.(uint64), v)
+	}
+	if a.strictRequestMidBinding.Load() {
+		return errNoRequestBound
+	}
+	return a.ResponseMid(atomic.LoadUint64(&a.lastMid), v)
 }
 
 // ResponseMid, implementation for session.NetworkEntity interface

--- a/cluster/cluster_http_lifecycle_test.go
+++ b/cluster/cluster_http_lifecycle_test.go
@@ -374,9 +374,13 @@ func TestHTTPLocalRequestResponse(t *testing.T) {
 type HTTPNotifyComp struct {
 	component.Base
 	got chan struct{}
+	err chan error
 }
 
 func (c *HTTPNotifyComp) Do(s *session.Session, _ []byte) error {
+	if c.err != nil {
+		c.err <- s.Response([]byte("unexpected"))
+	}
 	select {
 	case c.got <- struct{}{}:
 	default:
@@ -389,7 +393,7 @@ func TestHTTPLocalNotifyReturns200Immediately(t *testing.T) {
 	ensureScheduler()
 
 	n := newTestNode()
-	comp := &HTTPNotifyComp{got: make(chan struct{}, 1)}
+	comp := &HTTPNotifyComp{got: make(chan struct{}, 1), err: make(chan error, 1)}
 	if err := n.handler.register(comp, nil); err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -413,6 +417,14 @@ func TestHTTPLocalNotifyReturns200Immediately(t *testing.T) {
 	case <-comp.got:
 	case <-time.After(2 * time.Second):
 		t.Fatal("notify handler did not run; scheduler task blocked (H20)")
+	}
+	select {
+	case err := <-comp.err:
+		if err != ErrSessionOnNotify {
+			t.Fatalf("notify Response error = %v, want ErrSessionOnNotify", err)
+		}
+	default:
+		t.Fatal("notify handler did not attempt response")
 	}
 }
 

--- a/cluster/concurrent_routes_test.go
+++ b/cluster/concurrent_routes_test.go
@@ -1,0 +1,433 @@
+package cluster
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lonng/nano/component"
+	"github.com/lonng/nano/internal/log"
+	"github.com/lonng/nano/internal/message"
+	"github.com/lonng/nano/pipeline"
+	"github.com/lonng/nano/scheduler"
+	"github.com/lonng/nano/session"
+)
+
+type ConcurrentRouteComp struct {
+	component.Base
+	fn func(*session.Session, []byte) error
+}
+
+func (c *ConcurrentRouteComp) Allow(s *session.Session, data []byte) error {
+	return c.fn(s, data)
+}
+
+func (c *ConcurrentRouteComp) FIFO(s *session.Session, data []byte) error {
+	return c.fn(s, data)
+}
+
+type MixedLaneComp struct {
+	component.Base
+	allow  func(*session.Session, []byte) error
+	first  func(*session.Session, []byte) error
+	second func(*session.Session, []byte) error
+}
+
+func (c *MixedLaneComp) Allow(s *session.Session, data []byte) error {
+	return c.allow(s, data)
+}
+
+func (c *MixedLaneComp) First(s *session.Session, data []byte) error {
+	return c.first(s, data)
+}
+
+func (c *MixedLaneComp) Second(s *session.Session, data []byte) error {
+	return c.second(s, data)
+}
+
+type ResponseRouteComp struct {
+	component.Base
+	one func(*session.Session, []byte) error
+	two func(*session.Session, []byte) error
+}
+
+func (c *ResponseRouteComp) One(s *session.Session, data []byte) error {
+	return c.one(s, data)
+}
+
+func (c *ResponseRouteComp) Two(s *session.Session, data []byte) error {
+	return c.two(s, data)
+}
+
+type NotifySerialComp struct {
+	component.Base
+	fn func(*session.Session, []byte) error
+}
+
+func (c *NotifySerialComp) Handle(s *session.Session, data []byte) error {
+	return c.fn(s, data)
+}
+
+func registeredHandler(t *testing.T, h *LocalHandler, route string) *component.Handler {
+	t.Helper()
+	handler := h.localHandlers[route]
+	if handler == nil {
+		t.Fatalf("handler %s not registered", route)
+	}
+	return handler
+}
+
+func TestProcessMessageRunsInboundPipelineOnceForLocalHandler(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	ensureScheduler()
+	scheduler.DisableConcurrentRoutes()
+
+	pipe := pipeline.New()
+	var calls atomic.Int32
+	pipe.Inbound().PushBack(func(_ *session.Session, _ *message.Message) error {
+		calls.Add(1)
+		return nil
+	})
+
+	done := make(chan struct{})
+	comp := &NotifySerialComp{}
+	comp.fn = func(_ *session.Session, _ []byte) error {
+		close(done)
+		return nil
+	}
+	n := newTestNode()
+	n.handler = NewHandler(n, pipe)
+	if err := n.handler.register(comp, nil); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	a := newAgent(newCountConn(), pipe, nil)
+
+	n.handler.processMessage(a, &message.Message{Type: message.Notify, Route: "NotifySerialComp.Handle", Data: []byte("x")})
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not run")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("inbound pipeline calls = %d, want 1", got)
+	}
+}
+func TestConcurrentRouteRequestsSameSessionRunConcurrently(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	ensureScheduler()
+	scheduler.DisableConcurrentRoutes()
+	scheduler.EnableConcurrentRequests(2)
+	defer scheduler.DisableConcurrentRoutes()
+
+	started1 := make(chan struct{})
+	started2 := make(chan struct{})
+	release := make(chan struct{})
+	comp := &ConcurrentRouteComp{}
+	comp.fn = func(_ *session.Session, data []byte) error {
+		switch string(data) {
+		case "1":
+			close(started1)
+		case "2":
+			close(started2)
+		}
+		<-release
+		return nil
+	}
+
+	n := newTestNode()
+	n.handler.setConcurrentRoutePolicy([]string{"ConcurrentRouteComp.Allow"}, false)
+	if err := n.handler.register(comp, nil); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	handler := registeredHandler(t, n.handler, "ConcurrentRouteComp.Allow")
+	s := session.NewWithID(nil, 1001)
+
+	n.handler.localProcess(handler, 1, s, &message.Message{Type: message.Request, ID: 1, Route: "ConcurrentRouteComp.Allow", Data: []byte("1")}, nil)
+	n.handler.localProcess(handler, 2, s, &message.Message{Type: message.Request, ID: 2, Route: "ConcurrentRouteComp.Allow", Data: []byte("2")}, nil)
+
+	if !waitFor(func() bool {
+		select {
+		case <-started1:
+		default:
+			return false
+		}
+		select {
+		case <-started2:
+			return true
+		default:
+			return false
+		}
+	}, 3*time.Second) {
+		close(release)
+		t.Fatal("allowlisted same-session requests did not both start before release")
+	}
+	close(release)
+}
+
+func TestNonAllowlistedRequestsRemainFIFOUnderShardedScheduler(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	ensureScheduler()
+	scheduler.DisableConcurrentRoutes()
+	scheduler.EnableConcurrentRequests(2)
+	defer scheduler.DisableConcurrentRoutes()
+	scheduler.EnableSharded(4)
+	defer scheduler.DisableSharded()
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	comp := &ConcurrentRouteComp{}
+	comp.fn = func(_ *session.Session, data []byte) error {
+		switch string(data) {
+		case "first":
+			close(firstStarted)
+			<-releaseFirst
+		case "second":
+			close(secondStarted)
+		}
+		return nil
+	}
+
+	n := newTestNode()
+	n.handler.setConcurrentRoutePolicy([]string{"ConcurrentRouteComp.Allow"}, false)
+	if err := n.handler.register(comp, nil); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	handler := registeredHandler(t, n.handler, "ConcurrentRouteComp.FIFO")
+	s := session.NewWithID(nil, 1002)
+
+	n.handler.localProcess(handler, 1, s, &message.Message{Type: message.Request, ID: 1, Route: "ConcurrentRouteComp.FIFO", Data: []byte("first")}, nil)
+	select {
+	case <-firstStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first FIFO request did not start")
+	}
+	n.handler.localProcess(handler, 2, s, &message.Message{Type: message.Request, ID: 2, Route: "ConcurrentRouteComp.FIFO", Data: []byte("second")}, nil)
+	select {
+	case <-secondStarted:
+		close(releaseFirst)
+		t.Fatal("second same-session non-allowlisted request started before first completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	select {
+	case <-secondStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("second FIFO request did not run after first completed")
+	}
+}
+
+func TestConcurrentRouteRunsBesideBlockedFIFOLane(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	ensureScheduler()
+	scheduler.DisableConcurrentRoutes()
+	scheduler.EnableConcurrentRequests(2)
+	defer scheduler.DisableConcurrentRoutes()
+	scheduler.EnableSharded(4)
+	defer scheduler.DisableSharded()
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	allowStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	comp := &MixedLaneComp{}
+	comp.first = func(_ *session.Session, _ []byte) error {
+		close(firstStarted)
+		<-releaseFirst
+		return nil
+	}
+	comp.second = func(_ *session.Session, _ []byte) error {
+		close(secondStarted)
+		return nil
+	}
+	comp.allow = func(_ *session.Session, _ []byte) error {
+		close(allowStarted)
+		return nil
+	}
+
+	n := newTestNode()
+	n.handler.setConcurrentRoutePolicy([]string{"MixedLaneComp.Allow"}, false)
+	if err := n.handler.register(comp, nil); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	first := registeredHandler(t, n.handler, "MixedLaneComp.First")
+	second := registeredHandler(t, n.handler, "MixedLaneComp.Second")
+	allow := registeredHandler(t, n.handler, "MixedLaneComp.Allow")
+	s := session.NewWithID(nil, 1003)
+
+	n.handler.localProcess(first, 1, s, &message.Message{Type: message.Request, ID: 1, Route: "MixedLaneComp.First", Data: []byte("first")}, nil)
+	select {
+	case <-firstStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first FIFO request did not start")
+	}
+	n.handler.localProcess(second, 2, s, &message.Message{Type: message.Request, ID: 2, Route: "MixedLaneComp.Second", Data: []byte("second")}, nil)
+	n.handler.localProcess(allow, 3, s, &message.Message{Type: message.Request, ID: 3, Route: "MixedLaneComp.Allow", Data: []byte("allow")}, nil)
+
+	select {
+	case <-allowStarted:
+	case <-time.After(3 * time.Second):
+		close(releaseFirst)
+		t.Fatal("allowlisted request did not run while FIFO lane was blocked")
+	}
+	select {
+	case <-secondStarted:
+		close(releaseFirst)
+		t.Fatal("second FIFO request bypassed first FIFO request")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	select {
+	case <-secondStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("second FIFO request did not run after first completed")
+	}
+}
+
+func TestConcurrentAgentResponsesUseBoundRequestMid(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	ensureScheduler()
+	scheduler.DisableConcurrentRoutes()
+	scheduler.EnableConcurrentRequests(2)
+	defer scheduler.DisableConcurrentRoutes()
+
+	oneStarted := make(chan struct{})
+	twoStarted := make(chan struct{})
+	release := make(chan struct{})
+	comp := &ResponseRouteComp{}
+	comp.one = func(s *session.Session, _ []byte) error {
+		close(oneStarted)
+		<-twoStarted
+		<-release
+		return s.Response([]byte("one"))
+	}
+	comp.two = func(s *session.Session, _ []byte) error {
+		<-oneStarted
+		close(twoStarted)
+		<-release
+		return s.Response([]byte("two"))
+	}
+
+	n := newTestNode()
+	n.handler.setConcurrentRoutePolicy([]string{"ResponseRouteComp.One", "ResponseRouteComp.Two"}, false)
+	if err := n.handler.register(comp, nil); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	one := registeredHandler(t, n.handler, "ResponseRouteComp.One")
+	two := registeredHandler(t, n.handler, "ResponseRouteComp.Two")
+	a := newAgent(newCountConn(), nil, nil)
+	s := a.session
+
+	n.handler.localProcess(one, 11, s, &message.Message{Type: message.Request, ID: 11, Route: "ResponseRouteComp.One", Data: []byte("one")}, nil)
+	n.handler.localProcess(two, 22, s, &message.Message{Type: message.Request, ID: 22, Route: "ResponseRouteComp.Two", Data: []byte("two")}, nil)
+	select {
+	case <-twoStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("response handlers did not both start")
+	}
+	close(release)
+
+	got := map[uint64]string{}
+	deadline := time.After(3 * time.Second)
+	for len(got) < 2 {
+		select {
+		case m := <-a.chSend:
+			if m.typ != message.Response {
+				t.Fatalf("queued message type = %v, want response", m.typ)
+			}
+			b, ok := m.payload.([]byte)
+			if !ok {
+				t.Fatalf("response payload type = %T, want []byte", m.payload)
+			}
+			got[m.mid] = string(b)
+		case <-deadline:
+			t.Fatalf("timed out waiting for responses, got %v", got)
+		}
+	}
+	if got[11] != "one" || got[22] != "two" {
+		t.Fatalf("responses routed to wrong mids: %v", got)
+	}
+}
+
+func TestAgentAndAcceptorResponseRejectUnboundWhenConcurrentRoutesEnabled(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	scheduler.DisableConcurrentRoutes()
+	acNotify := &acceptor{}
+	acNotify.setLastMid(0)
+	if err := acNotify.Response([]byte("notify")); err != ErrSessionOnNotify {
+		t.Fatalf("acceptor notify Response = %v, want ErrSessionOnNotify", err)
+	}
+	if err := acNotify.ResponseMid(0, []byte("notify")); err != ErrSessionOnNotify {
+		t.Fatalf("acceptor ResponseMid(0) = %v, want ErrSessionOnNotify", err)
+	}
+
+	a := newAgent(newCountConn(), nil, nil)
+	a.setStrictRequestMidBinding(true)
+	a.setLastMid(99)
+	if err := a.Response([]byte("agent")); err != errNoRequestBound {
+		t.Fatalf("agent Response without bound mid = %v, want errNoRequestBound", err)
+	}
+
+	ac := &acceptor{}
+	ac.setStrictRequestMidBinding(true)
+	ac.setLastMid(99)
+	if err := ac.Response([]byte("acceptor")); err != errNoRequestBound {
+		t.Fatalf("acceptor Response without bound mid = %v, want errNoRequestBound", err)
+	}
+}
+
+func TestNotifySerializedWhenAllRequestsConcurrent(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	ensureScheduler()
+	scheduler.DisableConcurrentRoutes()
+	scheduler.EnableConcurrentRequests(2)
+	defer scheduler.DisableConcurrentRoutes()
+	scheduler.EnableSharded(4)
+	defer scheduler.DisableSharded()
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var once sync.Once
+	comp := &NotifySerialComp{}
+	comp.fn = func(_ *session.Session, _ []byte) error {
+		first := false
+		once.Do(func() { first = true })
+		if first {
+			close(firstStarted)
+			<-releaseFirst
+			return nil
+		}
+		close(secondStarted)
+		return nil
+	}
+
+	n := newTestNode()
+	n.handler.setConcurrentRoutePolicy(nil, true)
+	if err := n.handler.register(comp, nil); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	handler := registeredHandler(t, n.handler, "NotifySerialComp.Handle")
+	s := session.NewWithID(nil, 1004)
+
+	n.handler.localProcess(handler, 0, s, &message.Message{Type: message.Notify, Route: "NotifySerialComp.Handle", Data: []byte("first")}, nil)
+	select {
+	case <-firstStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first notify did not start")
+	}
+	n.handler.localProcess(handler, 0, s, &message.Message{Type: message.Notify, Route: "NotifySerialComp.Handle", Data: []byte("second")}, nil)
+	select {
+	case <-secondStarted:
+		close(releaseFirst)
+		t.Fatal("second notify started while first notify was blocked")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+	select {
+	case <-secondStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("second notify did not run after first completed")
+	}
+}

--- a/cluster/handler.go
+++ b/cluster/handler.go
@@ -154,6 +154,9 @@ type LocalHandler struct {
 
 	pipeline    pipeline.Pipeline
 	currentNode *Node
+
+	concurrentAllRequests bool
+	concurrentRoutes      map[string]struct{}
 }
 
 func NewHandler(currentNode *Node, pipeline pipeline.Pipeline) *LocalHandler {
@@ -166,6 +169,32 @@ func NewHandler(currentNode *Node, pipeline pipeline.Pipeline) *LocalHandler {
 	}
 
 	return h
+}
+
+func (h *LocalHandler) setConcurrentRoutePolicy(routes []string, allRequests bool) {
+	h.concurrentAllRequests = allRequests
+	if len(routes) == 0 {
+		h.concurrentRoutes = nil
+		return
+	}
+	h.concurrentRoutes = make(map[string]struct{}, len(routes))
+	for _, route := range routes {
+		if route != "" {
+			h.concurrentRoutes[route] = struct{}{}
+		}
+	}
+}
+
+func (h *LocalHandler) concurrentRoutesEnabled() bool {
+	return h.concurrentAllRequests || len(h.concurrentRoutes) > 0
+}
+
+func (h *LocalHandler) canRunRequestConcurrently(route string) bool {
+	if h.concurrentAllRequests {
+		return true
+	}
+	_, ok := h.concurrentRoutes[route]
+	return ok
 }
 
 func (h *LocalHandler) register(comp component.Component, opts []component.Option) error {
@@ -283,6 +312,7 @@ func (h *LocalHandler) handle(conn net.Conn) {
 		log.Error("handle: agent is nil after newAgent")
 		return
 	}
+	agent.setStrictRequestMidBinding(h.concurrentRoutesEnabled())
 
 	remoteAddr := agent.RemoteAddrWithoutPortStr()
 	if remoteAddr == "" {
@@ -492,7 +522,7 @@ func (h *LocalHandler) processPacket(agent *agent, p *packet.Packet) (err error)
 	switch p.Type {
 	case packet.Handshake:
 
-		agent.lastMid = 1
+		agent.setLastMid(1)
 		if err := env.HandshakeValidator(agent.session, p.Data); err != nil {
 			return err
 		}
@@ -723,7 +753,7 @@ func (h *LocalHandler) processMessage(agent *agent, msg *message.Message) {
 			log.Errorf("nano/handler: remote process route %s failed: %v", msg.Route, err)
 		}
 	} else {
-		h.localProcess(handler, lastMid, agent.session, msg, nil)
+		h.localProcessWithPipeline(handler, lastMid, agent.session, msg, nil, false)
 	}
 }
 
@@ -747,6 +777,17 @@ func (h *LocalHandler) localProcess(
 	msg *message.Message,
 	serializer serialize.Serializer,
 ) {
+	h.localProcessWithPipeline(handler, lastMid, session, msg, serializer, true)
+}
+
+func (h *LocalHandler) localProcessWithPipeline(
+	handler *component.Handler,
+	lastMid uint64,
+	session *session.Session,
+	msg *message.Message,
+	serializer serialize.Serializer,
+	processInbound bool,
+) {
 	// HTTP requests carry a JSON body while the cluster-wide env.Serializer may
 	// be binary (protobuf). Callers pass an explicit serializer for the inbound
 	// payload; nil falls back to the global serializer (M35).
@@ -754,11 +795,13 @@ func (h *LocalHandler) localProcess(
 		serializer = env.Serializer
 	}
 
-	if pipe := h.pipeline; pipe != nil {
-		err := pipe.Inbound().Process(session, msg)
-		if err != nil {
-			log.Println("Pipeline process failed: " + err.Error())
-			return
+	if processInbound {
+		if pipe := h.pipeline; pipe != nil {
+			err := pipe.Inbound().Process(session, msg)
+			if err != nil {
+				log.Println("Pipeline process failed: " + err.Error())
+				return
+			}
 		}
 	}
 
@@ -786,6 +829,14 @@ func (h *LocalHandler) localProcess(
 	if env.Debug {
 		log.Println(fmt.Sprintf("SID %d, UID=%d, Message={%s}, Data=%+v ClientUid=%d", session.ID(), session.UID(), msg.String(), data, session.ClientUid()))
 	}
+	if h.concurrentRoutesEnabled() {
+		switch v := session.NetworkEntity().(type) {
+		case *agent:
+			v.setStrictRequestMidBinding(true)
+		case *acceptor:
+			v.setStrictRequestMidBinding(true)
+		}
+	}
 
 	args := []reflect.Value{handler.Receiver, reflect.ValueOf(session), reflect.ValueOf(data)}
 
@@ -793,20 +844,16 @@ func (h *LocalHandler) localProcess(
 	startTime := time.Now()
 
 	task := func() {
-		// Bind the request mid before invoking the handler. For agent/acceptor
-		// (one connection == one session, processed sequentially) writing the
-		// field is safe; for httpAgent (one session shared by concurrent /api
-		// requests) the mid is bound to this goroutine for the synchronous call
-		// so a handler's session.Response routes to THIS request rather than a
-		// racing one that overwrote a shared field (H34).
 		var result []reflect.Value
 		switch v := session.NetworkEntity().(type) {
 		case *agent:
-			v.lastMid = lastMid
-			result = handler.Method.Func.Call(args)
+			v.runWithRequestMid(lastMid, func() {
+				result = handler.Method.Func.Call(args)
+			})
 		case *acceptor:
-			v.lastMid = lastMid
-			result = handler.Method.Func.Call(args)
+			v.runWithRequestMid(lastMid, func() {
+				result = handler.Method.Func.Call(args)
+			})
 		case *httpAgent:
 			v.runWithRequestMid(lastMid, func() {
 				result = handler.Method.Func.Call(args)
@@ -848,7 +895,20 @@ func (h *LocalHandler) localProcess(
 			return
 		}
 		local.Schedule(task)
-	} else if scheduler.Sharded() {
+		return
+	}
+
+	if msg.Type == message.Request && h.canRunRequestConcurrently(msg.Route) {
+		accepted, err := scheduler.ScheduleConcurrentRouteBlocking(msg.Route, task)
+		if err != nil {
+			log.Errorf("nano/handler: concurrent route scheduler failed, route=%s: %v", msg.Route, err)
+		}
+		if accepted {
+			return
+		}
+	}
+
+	if scheduler.Sharded() {
 		// Default path under sharding: route by session id so distinct sessions
 		// run concurrently while a single session stays strictly ordered. On
 		// backlog, shed the task (overload) instead of blocking the producer (H1).

--- a/cluster/http_agent.go
+++ b/cluster/http_agent.go
@@ -353,7 +353,11 @@ func (h *httpAgent) Response(v interface{}) error {
 	// shared lastMid here would let a later concurrent /api request reassign it
 	// and cross-wire (or drop) this response, so reject instead (H34).
 	if raw, ok := h.reqMids.Load(goID()); ok {
-		return h.ResponseMid(raw.(uint64), v)
+		mid := raw.(uint64)
+		if mid <= 0 {
+			return ErrSessionOnNotify
+		}
+		return h.ResponseMid(mid, v)
 	}
 	return errNoRequestBound
 }

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -97,6 +97,10 @@ type Options struct {
 	LimitConnectPerIp  uint
 	OpenPrometheus     bool
 	PrometheusAddr     string
+
+	ConcurrentRoutes           []string
+	ConcurrentAllRequests      bool
+	ConcurrentRouteConcurrency int
 }
 
 // Node represents a node in nano cluster, which will contain a group of services.
@@ -141,6 +145,7 @@ func (n *Node) Startup() error {
 	n.connectionCount = map[string]uint{}
 	n.cluster = newCluster(n)
 	n.handler = NewHandler(n, n.Pipeline)
+	n.handler.setConcurrentRoutePolicy(n.ConcurrentRoutes, n.ConcurrentAllRequests)
 	n.sseClients = map[string]chan []byte{}
 	components := n.Components.List()
 	for _, c := range components {
@@ -155,6 +160,11 @@ func (n *Node) Startup() error {
 	// is idempotent, so repeated node startups in one process enable it once.
 	if env.SchedulerShards > 0 {
 		scheduler.EnableSharded(env.SchedulerShards)
+	}
+	if n.handler.concurrentRoutesEnabled() {
+		// Route eligibility is node-scoped on LocalHandler; the scheduler only
+		// provides the shared bounded worker pool.
+		scheduler.EnableConcurrentRequests(n.ConcurrentRouteConcurrency)
 	}
 
 	cache()
@@ -463,11 +473,14 @@ func (n *Node) handleHTTPRequest(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Per-agent monotonic message id; wall-clock nanoseconds collided under
-	// concurrency and clobbered another in-flight request's context (H33).
-	messageID := agent.nextMid()
-	agent.AttackHttpRequestCtx(messageID, ctx)
-	defer agent.RemoveHttpRequestCtx(messageID)
+	var messageID uint64
+	if msgType == message.Request {
+		// Per-agent monotonic message id; wall-clock nanoseconds collided under
+		// concurrency and clobbered another in-flight request's context (H33).
+		messageID = agent.nextMid()
+		agent.AttackHttpRequestCtx(messageID, ctx)
+		defer agent.RemoveHttpRequestCtx(messageID)
+	}
 
 	// validate authenticate
 	if env.MiddlewareHttp != nil {
@@ -1091,6 +1104,7 @@ func (n *Node) findOrCreateSession(sid, clientUid int64, gateAddr string, client
 		gateAddr:    gateAddr,
 		jsonPayload: jsonPayload,
 	}
+	ac.setStrictRequestMidBinding(n.handler.concurrentRoutesEnabled())
 	s = session.New(ac)
 	ac.session = s
 	if err := applyClientState(s, clientUid, clientUserData); err != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -77,6 +77,34 @@ var (
 		},
 	)
 
+	ConcurrentSchedulePendingTasks = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "concurrent_schedule_pending_tasks",
+			Help: "Number of pending tasks in the concurrent route scheduler",
+		},
+	)
+
+	ConcurrentScheduleRunningTasks = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "concurrent_schedule_running_tasks",
+			Help: "Number of running tasks in the concurrent route scheduler",
+		},
+	)
+
+	ConcurrentScheduleBacklogTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "concurrent_schedule_backlog_total",
+			Help: "Total number of concurrent route scheduler backlog rejections",
+		},
+	)
+
+	ConcurrentScheduleRecoveredPanicTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "concurrent_schedule_recovered_panic_total",
+			Help: "Total number of panics recovered by concurrent route scheduler workers",
+		},
+	)
+
 	CPUUsage = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cpu_usage_percent",
@@ -112,6 +140,10 @@ func init() {
 	prometheus.MustRegister(ClientClosedConnections)
 	prometheus.MustRegister(ServerClosedConnections)
 	prometheus.MustRegister(SchedulePendingTasks)
+	prometheus.MustRegister(ConcurrentSchedulePendingTasks)
+	prometheus.MustRegister(ConcurrentScheduleRunningTasks)
+	prometheus.MustRegister(ConcurrentScheduleBacklogTotal)
+	prometheus.MustRegister(ConcurrentScheduleRecoveredPanicTotal)
 	prometheus.MustRegister(CPUUsage)
 	prometheus.MustRegister(CPUUserTime)
 	prometheus.MustRegister(CPUSystemTime)

--- a/options.go
+++ b/options.go
@@ -246,6 +246,44 @@ func WithScheduler(shards int) Option {
 	}
 }
 
+// WithConcurrentRoutes enables route-aware concurrent handling for the provided
+// request routes. By default nano preserves FIFO scheduling. Only listed
+// message.Request routes may run on the concurrent worker pool; Notifies and
+// non-listed Requests remain serialized. Nil or empty routes disable explicit
+// route concurrency and do not opt into all-request concurrency. concurrency < 0
+// is treated as 0.
+func WithConcurrentRoutes(routes []string, concurrency int) Option {
+	return func(opt *cluster.Options) {
+		if concurrency < 0 {
+			concurrency = 0
+		}
+		opt.ConcurrentAllRequests = false
+		opt.ConcurrentRouteConcurrency = concurrency
+		if len(routes) == 0 {
+			opt.ConcurrentRoutes = nil
+			return
+		}
+		opt.ConcurrentRoutes = append([]string(nil), routes...)
+	}
+}
+
+// WithConcurrentRequests enables dangerous all-request concurrent handling.
+// Default scheduling remains FIFO unless this option or WithConcurrentRoutes is
+// configured. Every message.Request may run on the concurrent worker pool with
+// no ordering guarantee relative to other Requests or the serialized lane;
+// Notifies remain serialized. Applications using this option must synchronize
+// shared, session, and domain state themselves. concurrency < 0 is treated as 0.
+func WithConcurrentRequests(concurrency int) Option {
+	return func(opt *cluster.Options) {
+		if concurrency < 0 {
+			concurrency = 0
+		}
+		opt.ConcurrentAllRequests = true
+		opt.ConcurrentRoutes = nil
+		opt.ConcurrentRouteConcurrency = concurrency
+	}
+}
+
 // WithMaxConnections sets a global cap on concurrently accepted connections.
 // n <= 0 means unlimited (default).
 func WithMaxConnections(n int) Option {

--- a/options_test.go
+++ b/options_test.go
@@ -1,6 +1,7 @@
 package nano
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -176,6 +177,57 @@ func TestWithScheduler(t *testing.T) {
 	WithScheduler(-1)(&cluster.Options{})
 	if env.SchedulerShards != 0 {
 		t.Fatalf("negative must clamp to 0, got %d", env.SchedulerShards)
+	}
+}
+
+func TestWithConcurrentRoutes(t *testing.T) {
+	var opt cluster.Options
+
+	routes := []string{"Chat.Send", "Room.Join"}
+	WithConcurrentRoutes(routes, 4)(&opt)
+	routes[0] = "mutated"
+	if !reflect.DeepEqual(opt.ConcurrentRoutes, []string{"Chat.Send", "Room.Join"}) {
+		t.Fatalf("routes must be copied, got %#v", opt.ConcurrentRoutes)
+	}
+	if opt.ConcurrentAllRequests {
+		t.Fatal("explicit routes must not enable all-request concurrency")
+	}
+	if opt.ConcurrentRouteConcurrency != 4 {
+		t.Fatalf("want concurrency 4, got %d", opt.ConcurrentRouteConcurrency)
+	}
+
+	WithConcurrentRoutes(nil, -1)(&opt)
+	if opt.ConcurrentAllRequests {
+		t.Fatal("nil routes must not enable all-request concurrency")
+	}
+	if len(opt.ConcurrentRoutes) != 0 {
+		t.Fatalf("nil routes must clear explicit routes, got %#v", opt.ConcurrentRoutes)
+	}
+	if opt.ConcurrentRouteConcurrency != 0 {
+		t.Fatalf("negative concurrency must clamp to 0, got %d", opt.ConcurrentRouteConcurrency)
+	}
+
+	opt.ConcurrentAllRequests = true
+	WithConcurrentRoutes([]string{}, 2)(&opt)
+	if opt.ConcurrentAllRequests {
+		t.Fatal("empty routes must not keep all-request concurrency enabled")
+	}
+	if len(opt.ConcurrentRoutes) != 0 {
+		t.Fatalf("empty routes must clear explicit routes, got %#v", opt.ConcurrentRoutes)
+	}
+}
+
+func TestWithConcurrentRequests(t *testing.T) {
+	opt := cluster.Options{ConcurrentRoutes: []string{"Chat.Send"}}
+	WithConcurrentRequests(-2)(&opt)
+	if !opt.ConcurrentAllRequests {
+		t.Fatal("all-request concurrency must be enabled")
+	}
+	if len(opt.ConcurrentRoutes) != 0 {
+		t.Fatalf("all-request concurrency must clear explicit routes, got %#v", opt.ConcurrentRoutes)
+	}
+	if opt.ConcurrentRouteConcurrency != 0 {
+		t.Fatalf("negative concurrency must clamp to 0, got %d", opt.ConcurrentRouteConcurrency)
 	}
 }
 

--- a/scheduler/concurrent_test.go
+++ b/scheduler/concurrent_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) nano Authors. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package scheduler
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestConcurrentRoutesAllowlistExactMatchAndCopiesRoutes(t *testing.T) {
+	DisableConcurrentRoutes()
+	t.Cleanup(DisableConcurrentRoutes)
+
+	routes := []string{"Svc.Safe"}
+	EnableConcurrentRoutes(routes, 1)
+	routes[0] = "Svc.Unsafe"
+
+	if !ConcurrentRoutesEnabled() {
+		t.Fatal("expected concurrent routes to be enabled")
+	}
+
+	run := make(chan struct{})
+	accepted, err := ScheduleConcurrentRoute("Svc.Safe", func() { close(run) })
+	if err != nil || !accepted {
+		t.Fatalf("safe route accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+	waitForSignal(t, run, "allowlisted task")
+
+	accepted, err = ScheduleConcurrentRoute("Svc", func() { t.Fatal("prefix route must not run") })
+	if err != nil || accepted {
+		t.Fatalf("prefix route accepted=%v err=%v, want not eligible", accepted, err)
+	}
+
+	accepted, err = ScheduleConcurrentRoute("Svc.Unsafe", func() { t.Fatal("mutated route must not run") })
+	if err != nil || accepted {
+		t.Fatalf("mutated route accepted=%v err=%v, want not eligible", accepted, err)
+	}
+
+	EnableConcurrentRoutes(nil, 1)
+	if ConcurrentRoutesEnabled() {
+		t.Fatal("nil routes should disable concurrent routes")
+	}
+	accepted, err = ScheduleConcurrentRoute("Svc.Safe", func() { t.Fatal("disabled route must not run") })
+	if err != nil || accepted {
+		t.Fatalf("disabled route accepted=%v err=%v, want not eligible", accepted, err)
+	}
+}
+
+func TestConcurrentRequestsAcceptsArbitraryRoute(t *testing.T) {
+	DisableConcurrentRoutes()
+	t.Cleanup(DisableConcurrentRoutes)
+
+	EnableConcurrentRequests(1)
+	run := make(chan struct{})
+	accepted, err := ScheduleConcurrentRoute("Anything.AtAll", func() { close(run) })
+	if err != nil || !accepted {
+		t.Fatalf("arbitrary route accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+	waitForSignal(t, run, "all-request task")
+}
+
+func TestConcurrentRoutesZeroConcurrencyUsesDefaultWorkers(t *testing.T) {
+	DisableConcurrentRoutes()
+	t.Cleanup(DisableConcurrentRoutes)
+
+	EnableConcurrentRoutes([]string{"Svc.Safe"}, 0)
+	if !ConcurrentRoutesEnabled() {
+		t.Fatal("zero concurrency should enable routes using the scheduler default")
+	}
+	run := make(chan struct{})
+	accepted, err := ScheduleConcurrentRoute("Svc.Safe", func() { close(run) })
+	if err != nil || !accepted {
+		t.Fatalf("zero-default route accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+	waitForSignal(t, run, "zero-default route task")
+
+	EnableConcurrentRequests(0)
+	run = make(chan struct{})
+	accepted, err = ScheduleConcurrentRoute("Anything.Route", func() { close(run) })
+	if err != nil || !accepted {
+		t.Fatalf("zero-default all-request accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+	waitForSignal(t, run, "zero-default all-request task")
+}
+
+func TestScheduleConcurrentRouteBacklogReturnsErrSchedulerBacklog(t *testing.T) {
+	DisableConcurrentRoutes()
+	t.Cleanup(DisableConcurrentRoutes)
+
+	EnableConcurrentRoutes([]string{"Svc.Safe"}, 1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	accepted, err := ScheduleConcurrentRoute("Svc.Safe", func() {
+		close(started)
+		<-release
+	})
+	if err != nil || !accepted {
+		t.Fatalf("wedging task accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+	waitForSignal(t, started, "wedging task start")
+	for i := 0; i < cap(chTasks); i++ {
+		accepted, err = ScheduleConcurrentRoute("Svc.Safe", func() {})
+		if err != nil || !accepted {
+			close(release)
+			t.Fatalf("buffer fill task %d accepted=%v err=%v, want accepted with nil error", i, accepted, err)
+		}
+	}
+
+	accepted, err = ScheduleConcurrentRoute("Svc.Safe", func() { t.Fatal("backlogged task must not run") })
+	if !accepted || !errors.Is(err, ErrSchedulerBacklog) {
+		close(release)
+		t.Fatalf("full executor accepted=%v err=%v, want accepted with ErrSchedulerBacklog", accepted, err)
+	}
+	close(release)
+}
+
+func TestScheduleConcurrentRouteBlockingWaitsThenRuns(t *testing.T) {
+	DisableConcurrentRoutes()
+	t.Cleanup(DisableConcurrentRoutes)
+
+	EnableConcurrentRoutes([]string{"Svc.Safe"}, 1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	accepted, err := ScheduleConcurrentRoute("Svc.Safe", func() {
+		close(started)
+		<-release
+	})
+	if err != nil || !accepted {
+		t.Fatalf("wedging task accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+	waitForSignal(t, started, "wedging task start")
+	for i := 0; i < cap(chTasks); i++ {
+		accepted, err = ScheduleConcurrentRoute("Svc.Safe", func() {})
+		if err != nil || !accepted {
+			close(release)
+			t.Fatalf("buffer fill task %d accepted=%v err=%v, want accepted with nil error", i, accepted, err)
+		}
+	}
+
+	blockingReturned := make(chan struct{})
+	blockingRan := make(chan struct{})
+	go func() {
+		accepted, err := ScheduleConcurrentRouteBlocking("Svc.Safe", func() { close(blockingRan) })
+		if err != nil || !accepted {
+			t.Errorf("blocking enqueue accepted=%v err=%v, want accepted with nil error", accepted, err)
+		}
+		close(blockingReturned)
+	}()
+
+	assertNoSignal(t, blockingReturned, "blocking enqueue returned before capacity was available")
+	close(release)
+	waitForSignal(t, blockingReturned, "blocking enqueue return")
+	waitForSignal(t, blockingRan, "blocking task")
+}
+
+func TestConcurrentRoutePanicRecoveryWorkerSurvives(t *testing.T) {
+	DisableConcurrentRoutes()
+	t.Cleanup(DisableConcurrentRoutes)
+
+	EnableConcurrentRoutes([]string{"Svc.Safe"}, 1)
+	accepted, err := ScheduleConcurrentRouteBlocking("Svc.Safe", func() { panic("boom") })
+	if err != nil || !accepted {
+		t.Fatalf("panic task accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+
+	survived := make(chan struct{})
+	accepted, err = ScheduleConcurrentRouteBlocking("Svc.Safe", func() { close(survived) })
+	if err != nil || !accepted {
+		t.Fatalf("survival task accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+	waitForSignal(t, survived, "post-panic task")
+}
+
+func TestDisableConcurrentRoutesDrainsAcceptedWorkAndDisablesEligibility(t *testing.T) {
+	DisableConcurrentRoutes()
+	t.Cleanup(DisableConcurrentRoutes)
+
+	EnableConcurrentRoutes([]string{"Svc.Safe"}, 1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var ran atomic.Int32
+	accepted, err := ScheduleConcurrentRoute("Svc.Safe", func() {
+		close(started)
+		ran.Add(1)
+		<-release
+	})
+	if err != nil || !accepted {
+		t.Fatalf("wedging task accepted=%v err=%v, want accepted with nil error", accepted, err)
+	}
+	waitForSignal(t, started, "wedging task start")
+	for i := 0; i < 3; i++ {
+		accepted, err = ScheduleConcurrentRoute("Svc.Safe", func() { ran.Add(1) })
+		if err != nil || !accepted {
+			close(release)
+			t.Fatalf("accepted task %d accepted=%v err=%v, want accepted with nil error", i, accepted, err)
+		}
+	}
+
+	disabled := make(chan struct{})
+	go func() {
+		DisableConcurrentRoutes()
+		close(disabled)
+	}()
+	assertNoSignal(t, disabled, "disable returned before running task completed")
+	close(release)
+	waitForSignal(t, disabled, "disable")
+
+	if got := ran.Load(); got != 4 {
+		t.Fatalf("ran %d accepted tasks, want 4", got)
+	}
+	if ConcurrentRoutesEnabled() {
+		t.Fatal("expected concurrent routes disabled")
+	}
+	accepted, err = ScheduleConcurrentRoute("Svc.Safe", func() { t.Fatal("disabled route must not run") })
+	if err != nil || accepted {
+		t.Fatalf("after disable accepted=%v err=%v, want not eligible", accepted, err)
+	}
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func assertNoSignal(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal(message)
+	case <-time.After(20 * time.Millisecond):
+	}
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -22,6 +22,7 @@ package scheduler
 
 import (
 	"fmt"
+	"runtime"
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
@@ -52,6 +53,20 @@ var (
 	chTasks = make(chan Task, 1<<8)
 	started int32
 	closed  int32
+)
+
+type concurrentRouteSet struct {
+	routes map[string]struct{}
+	all    bool
+	ch     chan Task
+	die    chan struct{}
+}
+
+var (
+	concurrentRouteMu sync.RWMutex
+	concurrentRoutes  *concurrentRouteSet
+	concurrentRouteOn atomic.Bool
+	concurrentRouteWG sync.WaitGroup
 )
 
 func try(f func()) {
@@ -167,6 +182,7 @@ func Close() {
 	// Tear down the sharded dispatcher (if enabled) so its worker goroutines do
 	// not outlive the scheduler. No-op in single-scheduler mode.
 	stopSharded()
+	stopConcurrentRoutes()
 	log.Println("Scheduler stopped")
 }
 
@@ -176,4 +192,164 @@ func PushTask(task Task) {
 	if env.Debug {
 		log.Infof("Scheduler push task channel size %d", len(chTasks))
 	}
+}
+
+func EnableConcurrentRoutes(routes []string, concurrency int) {
+	routeSet := make(map[string]struct{}, len(routes))
+	for _, route := range routes {
+		if route == "" {
+			continue
+		}
+		routeSet[route] = struct{}{}
+	}
+	if len(routeSet) == 0 {
+		DisableConcurrentRoutes()
+		return
+	}
+
+	startConcurrentRoutes(&concurrentRouteSet{
+		routes: routeSet,
+		ch:     make(chan Task, cap(chTasks)),
+		die:    make(chan struct{}),
+	}, normalizeConcurrentRouteConcurrency(concurrency))
+}
+
+func EnableConcurrentRequests(concurrency int) {
+	startConcurrentRoutes(&concurrentRouteSet{
+		all: true,
+		ch:  make(chan Task, cap(chTasks)),
+		die: make(chan struct{}),
+	}, normalizeConcurrentRouteConcurrency(concurrency))
+}
+
+func ConcurrentRoutesEnabled() bool {
+	return concurrentRouteOn.Load()
+}
+
+func ScheduleConcurrentRoute(route string, task Task) (bool, error) {
+	concurrentRouteMu.RLock()
+	set := concurrentRoutes
+	if !concurrentRouteEligible(set, route) {
+		concurrentRouteMu.RUnlock()
+		return false, nil
+	}
+	select {
+	case set.ch <- task:
+		metrics.ConcurrentSchedulePendingTasks.Set(float64(len(set.ch)))
+		concurrentRouteMu.RUnlock()
+		return true, nil
+	default:
+		metrics.ConcurrentScheduleBacklogTotal.Inc()
+		concurrentRouteMu.RUnlock()
+		return true, ErrSchedulerBacklog
+	}
+}
+
+func ScheduleConcurrentRouteBlocking(route string, task Task) (bool, error) {
+	concurrentRouteMu.RLock()
+	set := concurrentRoutes
+	if !concurrentRouteEligible(set, route) {
+		concurrentRouteMu.RUnlock()
+		return false, nil
+	}
+	set.ch <- task
+	metrics.ConcurrentSchedulePendingTasks.Set(float64(len(set.ch)))
+	concurrentRouteMu.RUnlock()
+	return true, nil
+}
+
+func DisableConcurrentRoutes() {
+	stopConcurrentRoutes()
+}
+
+func startConcurrentRoutes(next *concurrentRouteSet, concurrency int) {
+	stopConcurrentRoutes()
+
+	concurrentRouteMu.Lock()
+	defer concurrentRouteMu.Unlock()
+
+	if concurrentRoutes != nil {
+		return
+	}
+	concurrentRoutes = next
+	concurrentRouteOn.Store(true)
+	for i := 0; i < concurrency; i++ {
+		concurrentRouteWG.Add(1)
+		go concurrentRouteWorker(next.ch, next.die)
+	}
+}
+
+func normalizeConcurrentRouteConcurrency(concurrency int) int {
+	if concurrency <= 0 {
+		concurrency = runtime.GOMAXPROCS(0)
+	}
+	if concurrency < 1 {
+		return 1
+	}
+	return concurrency
+}
+
+func concurrentRouteEligible(set *concurrentRouteSet, route string) bool {
+	if set == nil {
+		return false
+	}
+	if set.all {
+		return true
+	}
+	_, ok := set.routes[route]
+	return ok
+}
+
+func concurrentRouteWorker(ch chan Task, die chan struct{}) {
+	defer concurrentRouteWG.Done()
+	for {
+		select {
+		case task := <-ch:
+			metrics.ConcurrentSchedulePendingTasks.Set(float64(len(ch)))
+			runConcurrentRouteTask(task)
+		case <-die:
+			drainConcurrentRouteChan(ch)
+			return
+		}
+	}
+}
+
+func drainConcurrentRouteChan(ch chan Task) {
+	for {
+		select {
+		case task := <-ch:
+			metrics.ConcurrentSchedulePendingTasks.Set(float64(len(ch)))
+			runConcurrentRouteTask(task)
+		default:
+			metrics.ConcurrentSchedulePendingTasks.Set(0)
+			return
+		}
+	}
+}
+
+func runConcurrentRouteTask(task Task) {
+	metrics.ConcurrentScheduleRunningTasks.Inc()
+	defer metrics.ConcurrentScheduleRunningTasks.Dec()
+	defer func() {
+		if err := recover(); err != nil {
+			metrics.ConcurrentScheduleRecoveredPanicTotal.Inc()
+			log.Println(fmt.Sprintf("Handle concurrent route panic: %+v\n%s", err, debug.Stack()))
+		}
+	}()
+	task()
+}
+
+func stopConcurrentRoutes() {
+	concurrentRouteMu.Lock()
+	defer concurrentRouteMu.Unlock()
+
+	set := concurrentRoutes
+	if set == nil {
+		return
+	}
+	concurrentRoutes = nil
+	concurrentRouteOn.Store(false)
+	close(set.die)
+	concurrentRouteWG.Wait()
+	drainConcurrentRouteChan(set.ch)
 }


### PR DESCRIPTION
## Summary
- add opt-in `WithConcurrentRoutes` allowlist and dangerous `WithConcurrentRequests` all-request concurrency mode
- add bounded concurrent request worker pool while preserving default FIFO behavior
- add request-scoped MID binding for agent/acceptor/httpAgent to prevent concurrent response cross-wiring
- keep Notify serialized and reject response-on-notify with `ErrSessionOnNotify`

## Tests
- `go test ./...`
- `go test -race ./scheduler ./cluster -run 'TestConcurrent|TestNonAllowlisted|TestNotifySerialized|TestAgentAndAcceptor|TestProcessMessageRunsInboundPipelineOnce|TestHTTPLocalNotifyReturns200Immediately' -count=1`

Closes #12