### PR TITLE
feat(cluster): add rollout-safe health primitives

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -38,8 +38,9 @@ import (
 // from client will send to gate firstly and be forwarded to appropriate node.
 type cluster struct {
 	// If cluster is not large enough, use slice is OK
-	currentNode *Node
-	rpcClient   *rpcClient
+	currentNode  *Node
+	rpcClient    *rpcClient
+	pingMemberFn func(context.Context, string) error
 
 	mu                sync.RWMutex
 	members           []*Member
@@ -132,9 +133,13 @@ func (c *cluster) Register(_ context.Context, req *clusterpb.RegisterRequest) (*
 		membershipVersion: c.membershipVersion,
 	})
 	c.mu.Unlock()
+	if c.rpcClient != nil {
+		c.rpcClient.allowPool(req.MemberInfo.ServiceAddr)
+	}
 
-	c.currentNode.handler.delMember(req.MemberInfo.ServiceAddr)
-	c.currentNode.handler.addRemoteService(req.MemberInfo)
+	if c.currentNode != nil {
+		c.currentNode.addRemoteMemberIfCurrent(req.MemberInfo)
+	}
 
 	log.Println("New peer register to cluster", req.MemberInfo.ServiceAddr)
 
@@ -160,27 +165,25 @@ func (c *cluster) Register(_ context.Context, req *clusterpb.RegisterRequest) (*
 }
 
 // Unregister implements the MasterServer gRPC service
-func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest) (*clusterpb.UnregisterResponse, error) {
+func (c *cluster) Unregister(ctx context.Context, req *clusterpb.UnregisterRequest) (*clusterpb.UnregisterResponse, error) {
 	if req == nil || req.ServiceAddr == "" {
 		return nil, ErrInvalidRegisterReq
 	}
 
 	resp := &clusterpb.UnregisterResponse{}
+	snapshot := c.memberSnapshots()
 
-	c.mu.RLock()
-	snapshot := make([]*Member, len(c.members))
-	copy(snapshot, c.members)
-	c.mu.RUnlock()
-
-	var target *Member
+	var target memberSnapshot
+	var foundTarget bool
 	for _, m := range snapshot {
-		if m.memberInfo.ServiceAddr == req.ServiceAddr {
+		if m.serviceAddr == req.ServiceAddr {
 			target = m
+			foundTarget = true
 			break
 		}
 	}
-	if target == nil {
-		return nil, fmt.Errorf("address %s has not registered", req.ServiceAddr)
+	if !foundTarget {
+		return resp, nil
 	}
 
 	var (
@@ -190,14 +193,14 @@ func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest
 	c.mu.Lock()
 	index := -1
 	for i, m := range c.members {
-		if m.memberInfo.ServiceAddr == req.ServiceAddr {
+		if m.memberInfo != nil && m.memberInfo.ServiceAddr == req.ServiceAddr {
 			index = i
 			break
 		}
 	}
 	if index < 0 {
 		c.mu.Unlock()
-		return nil, fmt.Errorf("address %s has not registered", req.ServiceAddr)
+		return resp, nil
 	}
 	c.membershipVersion++
 	membershipEpoch = c.ensureMembershipEpochLocked()
@@ -211,36 +214,41 @@ func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest
 	c.mu.Unlock()
 
 	if c.currentNode != nil {
-		c.currentNode.removeRemoteMember(req.ServiceAddr)
+		c.currentNode.removeRemoteMemberIfAbsent(req.ServiceAddr)
 	}
 
 	log.Println("Exists peer unregister to cluster", req.ServiceAddr)
 
 	delMember := &clusterpb.DelMemberRequest{ServiceAddr: req.ServiceAddr, MembershipVersion: version, MembershipEpoch: membershipEpoch}
 	for _, m := range snapshot {
-		if m.memberInfo.ServiceAddr == req.ServiceAddr {
+		if m.serviceAddr == "" || m.serviceAddr == req.ServiceAddr {
 			continue
 		}
-		if m.MemberInfo().ServiceAddr == c.currentNode.ServiceAddr {
+		if c.currentNode != nil && m.serviceAddr == c.currentNode.ServiceAddr {
 			continue
 		}
-		pool, err := c.rpcClient.getConnPool(m.memberInfo.ServiceAddr)
+		notifyCtx := ctx
+		if notifyCtx.Err() != nil {
+			notifyCtx = context.Background()
+		}
+		pool, err := c.rpcClient.getConnPoolWithContext(notifyCtx, m.serviceAddr)
 		if err != nil {
-			log.Errorf("cluster: notify del member %s -> %s failed: %v", req.ServiceAddr, m.memberInfo.ServiceAddr, err)
+			log.Errorf("cluster: notify del member %s -> %s failed: %v", req.ServiceAddr, m.serviceAddr, err)
 			continue
 		}
 		client := clusterpb.NewMemberClient(pool.Get())
-		ctx, cancel := context.WithTimeout(context.Background(), remoteRPCTimeout)
-		_, err = client.DelMember(ctx, delMember)
+		peerCtx, cancel := context.WithTimeout(notifyCtx, remoteRPCTimeout)
+		_, err = client.DelMember(peerCtx, delMember)
 		cancel()
 		if err != nil {
-			log.Errorf("cluster: notify del member %s -> %s failed: %v", req.ServiceAddr, m.memberInfo.ServiceAddr, err)
+			log.Errorf("cluster: notify del member %s -> %s failed: %v", req.ServiceAddr, m.serviceAddr, err)
 		}
 	}
 
-	if c.currentNode.UnregisterCallback != nil {
-		removedInfo := target.MemberInfo()
-		c.currentNode.UnregisterCallback(*target, func() {
+	if c.currentNode != nil && c.currentNode.UnregisterCallback != nil {
+		removedInfo := cloneMemberInfo(target.memberInfo)
+		removedMember := target.member()
+		c.currentNode.UnregisterCallback(removedMember, func() {
 			log.Println("UnregisterCallback")
 			res, err := c.Register(context.Background(), &clusterpb.RegisterRequest{
 				MemberInfo: removedInfo,
@@ -320,8 +328,8 @@ func (c *cluster) Heartbeat(_ context.Context, req *clusterpb.HeartbeatRequest) 
 	}
 	c.mu.Unlock()
 
-	if addedMember != nil {
-		c.currentNode.handler.addRemoteService(addedMember)
+	if addedMember != nil && c.currentNode != nil {
+		c.currentNode.addRemoteMemberIfCurrent(addedMember)
 	}
 	return resp, nil
 }
@@ -332,24 +340,22 @@ func (c *cluster) checkMemberHeartbeat() {
 	check := func() {
 		// Snapshot members under the lock so the check never reads the live
 		// backing array concurrently with membership mutations (H4).
-		c.mu.RLock()
-		snapshot := make([]*Member, len(c.members))
-		copy(snapshot, c.members)
-		c.mu.RUnlock()
+		snapshot := c.memberSnapshots()
 
-		unregisterMembers := make([]*Member, 0)
+		unregisterMembers := make([]memberSnapshot, 0)
 		// check heartbeat time
+		now := time.Now()
 		for _, m := range snapshot {
-			log.Infof("Check heartbeat for %s, last heartbeat: %v, diff %v, deadline: %v", m.MemberInfo().ServiceAddr, m.lastHeartbeatAt, time.Now().Sub(m.lastHeartbeatAt), 4*env.Heartbeat)
-			if time.Now().Sub(m.lastHeartbeatAt) > 4*env.Heartbeat && !m.isMaster {
+			log.Infof("Check heartbeat for %s, last heartbeat: %v, diff %v, deadline: %v", m.serviceAddr, m.lastHeartbeatAt, now.Sub(m.lastHeartbeatAt), 4*env.Heartbeat)
+			if now.Sub(m.lastHeartbeatAt) > 4*env.Heartbeat && !m.isMaster {
 				unregisterMembers = append(unregisterMembers, m)
 			}
 		}
 
 		for _, m := range unregisterMembers {
-			log.Println("Heartbeat timeout, unregister: ", m.MemberInfo().Label, m.MemberInfo().ServiceAddr)
+			log.Println("Heartbeat timeout, unregister: ", m.label, m.serviceAddr)
 			if _, err := c.Unregister(context.Background(), &clusterpb.UnregisterRequest{
-				ServiceAddr: m.MemberInfo().ServiceAddr,
+				ServiceAddr: m.serviceAddr,
 			}); err != nil {
 				log.Println("Heartbeat unregister error", err)
 			}
@@ -391,10 +397,7 @@ func (c *cluster) stopHeartbeatChecker() {
 func (c *cluster) pingNodes(withLabels []string) (lives []string, dies []string, err error) {
 	// Snapshot the membership so iteration never races concurrent
 	// register/unregister mutations of the backing array (H4).
-	c.mu.RLock()
-	snapshot := make([]*Member, len(c.members))
-	copy(snapshot, c.members)
-	c.mu.RUnlock()
+	snapshot := c.memberSnapshots()
 	for _, m := range snapshot {
 		if m.isMaster {
 			continue
@@ -402,8 +405,8 @@ func (c *cluster) pingNodes(withLabels []string) (lives []string, dies []string,
 		if c.rpcClient == nil {
 			return nil, nil, fmt.Errorf("rpc client is nil")
 		}
-		log.Debug("Ping node: ", m.memberInfo.Label)
-		pool, err := c.rpcClient.getConnPool(m.memberInfo.ServiceAddr)
+		log.Debug("Ping node: ", m.label)
+		pool, err := c.rpcClient.getConnPool(m.serviceAddr)
 		if pool == nil {
 			log.Error("Get connection pool error", err)
 			continue
@@ -415,14 +418,14 @@ func (c *cluster) pingNodes(withLabels []string) (lives []string, dies []string,
 		client := clusterpb.NewMemberClient(pool.Get())
 		// log.Println("Get client: ", client)
 		if resp, err := client.Ping(context.Background(), &clusterpb.PingRequest{}); err != nil {
-			log.Error("Ping node error", m.memberInfo.Label, err)
-			dies = append(dies, m.memberInfo.Label)
+			log.Error("Ping node error", m.label, err)
+			dies = append(dies, m.label)
 		} else {
-			log.Debugf("Ping node %s, label %s success, response: %s", m.memberInfo.ServiceAddr, m.memberInfo.Label, string(resp.String()))
+			log.Debugf("Ping node %s, label %s success, response: %s", m.serviceAddr, m.label, string(resp.String()))
 			if resp.Msg == "pong" {
-				lives = append(lives, m.memberInfo.Label)
+				lives = append(lives, m.label)
 			} else {
-				dies = append(dies, m.memberInfo.Label)
+				dies = append(dies, m.label)
 			}
 		}
 	}
@@ -430,7 +433,7 @@ func (c *cluster) pingNodes(withLabels []string) (lives []string, dies []string,
 	for _, label := range withLabels {
 		var found bool
 		for _, m := range snapshot {
-			if m.memberInfo.Label == label {
+			if m.label == label {
 				found = true
 			}
 		}
@@ -460,6 +463,9 @@ func (c *cluster) initMembers(members []*clusterpb.MemberInfo, membershipVersion
 	c.mu.Lock()
 	c.acceptMembershipSnapshotLocked(membershipVersion, membershipEpoch, 0)
 	for _, info := range members {
+		if c.rpcClient != nil {
+			c.rpcClient.allowPool(info.ServiceAddr)
+		}
 		c.members = append(c.members, &Member{
 			memberInfo:        info,
 			membershipEpoch:   c.membershipEpoch,
@@ -479,6 +485,9 @@ func (c *cluster) addMember(info *clusterpb.MemberInfo, membershipVersion, membe
 		return false
 	}
 	c.clearRemovedMemberLocked(info.GetServiceAddr())
+	if c.rpcClient != nil {
+		c.rpcClient.allowPool(info.GetServiceAddr())
+	}
 	now := time.Now()
 	var found bool
 	for _, member := range c.members {
@@ -555,6 +564,9 @@ func (c *cluster) reconcileMembersSnapshot(infos []*clusterpb.MemberInfo, remove
 			continue
 		}
 		snapshotMembers[info.ServiceAddr] = struct{}{}
+		if c.rpcClient != nil {
+			c.rpcClient.allowPool(info.ServiceAddr)
+		}
 		if member, ok := known[info.ServiceAddr]; ok {
 			if !memberInfoEqual(member.memberInfo, info) {
 				member.memberInfo = info

--- a/cluster/connpool.go
+++ b/cluster/connpool.go
@@ -47,6 +47,7 @@ type rpcClient struct {
 	// the global lock held — otherwise one slow address stalls every concurrent
 	// getConnPool caller (routing / heartbeat / session-close) (M15).
 	dialing map[string]*sync.Mutex
+	removed map[string]struct{}
 }
 
 // clusterAuthClientInterceptor attaches the configured shared token to every
@@ -67,17 +68,21 @@ func clusterAuthClientInterceptor(
 }
 
 func newConnArray(maxSize uint, addr string) (*connPool, error) {
+	return newConnArrayContext(context.Background(), maxSize, addr)
+}
+
+func newConnArrayContext(ctx context.Context, maxSize uint, addr string) (*connPool, error) {
 	a := &connPool{
 		index: 0,
 		v:     make([]*grpc.ClientConn, maxSize),
 	}
-	if err := a.init(addr); err != nil {
+	if err := a.init(ctx, addr); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-func (a *connPool) init(addr string) error {
+func (a *connPool) init(ctx context.Context, addr string) error {
 	// Attach the cluster auth client interceptor so outbound RPCs carry the
 	// shared token when configured (H9). Copy env.GrpcOptions so the shared
 	// slice is never mutated.
@@ -85,9 +90,9 @@ func (a *connPool) init(addr string) error {
 	opts = append(opts, env.GrpcOptions...)
 	opts = append(opts, grpc.WithChainUnaryInterceptor(clusterAuthClientInterceptor))
 	for i := range a.v {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		dialCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		conn, err := grpc.DialContext(
-			ctx,
+			dialCtx,
 			fmt.Sprintf("dns:///%s", addr),
 			opts...,
 		)
@@ -124,20 +129,32 @@ func newRPCClient() *rpcClient {
 	return &rpcClient{
 		pools:   make(map[string]*connPool),
 		dialing: make(map[string]*sync.Mutex),
+		removed: make(map[string]struct{}),
 	}
 }
 
 func (c *rpcClient) getConnPool(addr string) (*connPool, error) {
+	return c.getConnPoolWithContext(context.Background(), addr)
+}
+
+func (c *rpcClient) getConnPoolWithContext(ctx context.Context, addr string) (*connPool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	c.RLock()
 	if c.isClosed {
 		c.RUnlock()
 		return nil, errors.New("rpc client is closed")
 	}
+	if _, removed := c.removed[addr]; removed {
+		c.RUnlock()
+		return nil, errors.New("rpc client pool removed")
+	}
 	array, ok := c.pools[addr]
 	c.RUnlock()
 	if !ok {
 		var err error
-		array, err = c.createConnPool(addr)
+		array, err = c.createConnPoolWithContext(ctx, addr)
 		if err != nil {
 			return nil, err
 		}
@@ -146,6 +163,10 @@ func (c *rpcClient) getConnPool(addr string) (*connPool, error) {
 }
 
 func (c *rpcClient) createConnPool(addr string) (*connPool, error) {
+	return c.createConnPoolWithContext(context.Background(), addr)
+}
+
+func (c *rpcClient) createConnPoolWithContext(ctx context.Context, addr string) (*connPool, error) {
 	// Grab (or create) the per-address dial lock under the global lock, then
 	// release the global lock before dialing so concurrent getConnPool callers
 	// for other addresses are never blocked by a slow dial (M15).
@@ -153,6 +174,10 @@ func (c *rpcClient) createConnPool(addr string) (*connPool, error) {
 	if c.isClosed {
 		c.Unlock()
 		return nil, errors.New("rpc client is closed")
+	}
+	if _, removed := c.removed[addr]; removed {
+		c.Unlock()
+		return nil, errors.New("rpc client pool removed")
 	}
 	if array, ok := c.pools[addr]; ok {
 		c.Unlock()
@@ -165,9 +190,23 @@ func (c *rpcClient) createConnPool(addr string) (*connPool, error) {
 	}
 	c.Unlock()
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Only one goroutine dials a given address at a time.
 	dm.Lock()
 	defer dm.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c.RLock()
+	_, removed := c.removed[addr]
+	c.RUnlock()
+	if removed {
+		return nil, errors.New("rpc client pool removed")
+	}
 
 	// Re-check: another goroutine may have built the pool while we waited.
 	c.RLock()
@@ -178,7 +217,7 @@ func (c *rpcClient) createConnPool(addr string) (*connPool, error) {
 	}
 
 	// TODO: make conn count configurable
-	array, err := newConnArray(10, addr)
+	array, err := newConnArrayContext(ctx, 10, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -188,6 +227,11 @@ func (c *rpcClient) createConnPool(addr string) (*connPool, error) {
 		c.Unlock()
 		array.Close()
 		return nil, errors.New("rpc client is closed")
+	}
+	if _, removed := c.removed[addr]; removed {
+		c.Unlock()
+		array.Close()
+		return nil, errors.New("rpc client pool removed")
 	}
 	c.pools[addr] = array
 	c.Unlock()
@@ -213,12 +257,41 @@ func (c *rpcClient) closePool() {
 // Close cannot stall concurrent getConnPool callers.
 func (c *rpcClient) removePool(addr string) {
 	c.Lock()
+	if c.removed == nil {
+		c.removed = make(map[string]struct{})
+	}
+	c.removed[addr] = struct{}{}
 	pool, ok := c.pools[addr]
 	if ok {
 		delete(c.pools, addr)
 	}
+	dm := c.dialing[addr]
 	c.Unlock()
 	if ok {
 		pool.Close()
 	}
+
+	if dm == nil {
+		return
+	}
+	dm.Lock()
+	c.Lock()
+	pool, ok = c.pools[addr]
+	if ok {
+		delete(c.pools, addr)
+	}
+	delete(c.dialing, addr)
+	c.Unlock()
+	dm.Unlock()
+	if ok {
+		pool.Close()
+	}
+}
+
+func (c *rpcClient) allowPool(addr string) {
+	c.Lock()
+	if c.removed != nil {
+		delete(c.removed, addr)
+	}
+	c.Unlock()
 }

--- a/cluster/connpool_test.go
+++ b/cluster/connpool_test.go
@@ -1,0 +1,45 @@
+package cluster
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRemovePoolWaitsForInFlightCreate(t *testing.T) {
+	const addr = "stale:8088"
+	rc := newRPCClient()
+	dialLock := &sync.Mutex{}
+	dialLock.Lock()
+	rc.dialing[addr] = dialLock
+
+	done := make(chan struct{})
+	go func() {
+		rc.removePool(addr)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("removePool returned while createConnPool was still in-flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	rc.Lock()
+	rc.pools[addr] = &connPool{}
+	rc.Unlock()
+	dialLock.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("removePool did not return after in-flight create completed")
+	}
+
+	rc.RLock()
+	_, ok := rc.pools[addr]
+	rc.RUnlock()
+	if ok {
+		t.Fatalf("pool for %s was republished after removePool", addr)
+	}
+}

--- a/cluster/health.go
+++ b/cluster/health.go
@@ -1,0 +1,177 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/lonng/nano/cluster/clusterpb"
+)
+
+const maxHealthProbeConcurrency = 32
+
+// HealthReport describes cluster member health at both label and address level.
+// Labels are unique by Label. Members contains one row for each probed member.
+type HealthReport struct {
+	Labels  []LabelHealth
+	Members []MemberHealth
+}
+
+// LabelHealth summarizes live/dead member counts for one service label. For
+// non-missing labels, Total equals Live+Dead. Missing means a requested label had
+// no matching member candidates, so no member was dialed for that label.
+type LabelHealth struct {
+	Label   string
+	Total   int
+	Live    int
+	Dead    int
+	Missing bool
+}
+
+// MemberHealth describes the health result for one advertised member address.
+// Error is diagnostic text for a non-live probe and is empty for live members.
+type MemberHealth struct {
+	Label       string
+	ServiceAddr string
+	Alive       bool
+	Error       string
+}
+
+// CheckClusterHealth probes cluster members matching labels and reports per-label
+// and per-address health. When labels is non-empty, members with other labels are
+// filtered before any dial or ping is attempted.
+func (n *Node) CheckClusterHealth(ctx context.Context, labels []string) (*HealthReport, error) {
+	if ctx == nil {
+		return nil, errors.New("nil context")
+	}
+	if n == nil || n.cluster == nil {
+		return nil, fmt.Errorf("Node is not initialized")
+	}
+	return n.cluster.checkClusterHealth(ctx, labels)
+}
+
+func (c *cluster) checkClusterHealth(ctx context.Context, labels []string) (*HealthReport, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Node is not initialized")
+	}
+
+	snapshot := c.memberSnapshots()
+
+	report := &HealthReport{}
+	requested := makeLabelSet(labels)
+	labelIndex := make(map[string]int, len(labels))
+
+	// Pre-populate every requested label as Missing; the candidate scan below
+	// clears Missing and accumulates live/dead counts for labels that match a member.
+	for _, label := range labels {
+		if _, exists := labelIndex[label]; exists {
+			continue
+		}
+		labelIndex[label] = len(report.Labels)
+		report.Labels = append(report.Labels, LabelHealth{Label: label, Missing: true})
+	}
+
+	candidates := make([]memberSnapshot, 0, len(snapshot))
+	for _, m := range snapshot {
+		if m.isMaster || m.serviceAddr == "" {
+			continue
+		}
+		label := m.label
+		if len(requested) > 0 {
+			if _, ok := requested[label]; !ok {
+				continue
+			}
+		}
+		if _, exists := labelIndex[label]; !exists {
+			labelIndex[label] = len(report.Labels)
+			report.Labels = append(report.Labels, LabelHealth{Label: label})
+		}
+		idx := labelIndex[label]
+		report.Labels[idx].Total++
+		report.Labels[idx].Missing = false
+		candidates = append(candidates, m)
+	}
+
+	if len(candidates) == 0 {
+		return report, nil
+	}
+
+	report.Members = make([]MemberHealth, len(candidates))
+	semSize := len(candidates)
+	if semSize > maxHealthProbeConcurrency {
+		semSize = maxHealthProbeConcurrency
+	}
+	sem := make(chan struct{}, semSize)
+	var wg sync.WaitGroup
+	for i, m := range candidates {
+		i, m := i, m
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				report.Members[i] = memberHealthFromError(m, ctx.Err())
+				return
+			}
+			if err := c.pingMember(ctx, m.serviceAddr); err != nil {
+				report.Members[i] = memberHealthFromError(m, err)
+				return
+			}
+			report.Members[i] = MemberHealth{Label: m.label, ServiceAddr: m.serviceAddr, Alive: true}
+		}()
+	}
+	wg.Wait()
+
+	for _, member := range report.Members {
+		idx := labelIndex[member.Label]
+		if member.Alive {
+			report.Labels[idx].Live++
+		} else {
+			report.Labels[idx].Dead++
+		}
+	}
+	return report, nil
+}
+
+func makeLabelSet(labels []string) map[string]struct{} {
+	if len(labels) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		set[label] = struct{}{}
+	}
+	return set
+}
+
+func memberHealthFromError(m memberSnapshot, err error) MemberHealth {
+	mh := MemberHealth{Label: m.label, ServiceAddr: m.serviceAddr}
+	if err != nil {
+		mh.Error = err.Error()
+	}
+	return mh
+}
+
+func (c *cluster) pingMember(ctx context.Context, addr string) error {
+	if c.pingMemberFn != nil {
+		return c.pingMemberFn(ctx, addr)
+	}
+	if c.rpcClient == nil {
+		return fmt.Errorf("rpc client is nil")
+	}
+	pool, err := c.rpcClient.getConnPoolWithContext(ctx, addr)
+	if err != nil {
+		return err
+	}
+	resp, err := clusterpb.NewMemberClient(pool.Get()).Ping(ctx, &clusterpb.PingRequest{})
+	if err != nil {
+		return err
+	}
+	if resp.GetMsg() != "pong" {
+		return fmt.Errorf("unexpected ping response %q", resp.GetMsg())
+	}
+	return nil
+}

--- a/cluster/health_test.go
+++ b/cluster/health_test.go
@@ -1,0 +1,159 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/lonng/nano/cluster/clusterpb"
+)
+
+func TestCheckClusterHealthFiltersUnrequestedLabelsBeforePing(t *testing.T) {
+	n := newTestNode()
+	c := n.cluster
+	c.members = []*Member{
+		{memberInfo: mkMemberInfo("user-service", "user-live:8088")},
+		{memberInfo: mkMemberInfo("chat-service", "chat-stale:8088")},
+	}
+
+	var called []string
+	c.pingMemberFn = func(_ context.Context, addr string) error {
+		called = append(called, addr)
+		if addr == "chat-stale:8088" {
+			return errors.New("unrequested stale member was dialed")
+		}
+		return nil
+	}
+
+	report, err := n.CheckClusterHealth(context.Background(), []string{"user-service"})
+	if err != nil {
+		t.Fatalf("CheckClusterHealth returned error: %v", err)
+	}
+	if !reflect.DeepEqual(called, []string{"user-live:8088"}) {
+		t.Fatalf("pinged addresses = %v, want only requested label address", called)
+	}
+	assertLabelHealth(t, report, "user-service", LabelHealth{Label: "user-service", Total: 1, Live: 1, Dead: 0})
+	if len(report.Members) != 1 || report.Members[0].ServiceAddr != "user-live:8088" || !report.Members[0].Alive {
+		t.Fatalf("members = %+v, want one live user-service member", report.Members)
+	}
+}
+
+func TestCheckClusterHealthReportsMissingRequestedLabelWithoutDialingUnrequestedMembers(t *testing.T) {
+	n := newTestNode()
+	c := n.cluster
+	c.members = []*Member{{memberInfo: mkMemberInfo("chat-service", "chat-stale:8088")}}
+
+	var called []string
+	c.pingMemberFn = func(_ context.Context, addr string) error {
+		called = append(called, addr)
+		return errors.New("unexpected dial")
+	}
+
+	report, err := n.CheckClusterHealth(context.Background(), []string{"user-service"})
+	if err != nil {
+		t.Fatalf("CheckClusterHealth returned error: %v", err)
+	}
+	if len(called) != 0 {
+		t.Fatalf("pinged addresses = %v, want none for missing requested label", called)
+	}
+	assertLabelHealth(t, report, "user-service", LabelHealth{Label: "user-service", Missing: true})
+	if len(report.Members) != 0 {
+		t.Fatalf("members = %+v, want none", report.Members)
+	}
+}
+
+func TestCheckClusterHealthReportsSameLabelReplicaDetails(t *testing.T) {
+	n := newTestNode()
+	c := n.cluster
+	c.members = []*Member{
+		{memberInfo: mkMemberInfo("user-service", "user-live:8088")},
+		{memberInfo: mkMemberInfo("user-service", "user-dead:8088")},
+		{memberInfo: mkMemberInfo("chat-service", "chat-stale:8088")},
+	}
+	c.pingMemberFn = func(_ context.Context, addr string) error {
+		if addr == "user-dead:8088" {
+			return errors.New("connection refused")
+		}
+		if addr == "chat-stale:8088" {
+			return errors.New("unrequested stale member was dialed")
+		}
+		return nil
+	}
+
+	report, err := n.CheckClusterHealth(context.Background(), []string{"user-service"})
+	if err != nil {
+		t.Fatalf("CheckClusterHealth returned error: %v", err)
+	}
+	assertLabelHealth(t, report, "user-service", LabelHealth{Label: "user-service", Total: 2, Live: 1, Dead: 1})
+	if len(report.Members) != 2 {
+		t.Fatalf("members = %+v, want two user-service entries", report.Members)
+	}
+	assertMemberHealth(t, report, "user-live:8088", true)
+	assertMemberHealth(t, report, "user-dead:8088", false)
+}
+
+func TestCheckClusterHealthReportsAllDeadSameLabel(t *testing.T) {
+	n := newTestNode()
+	c := n.cluster
+	c.members = []*Member{
+		{memberInfo: mkMemberInfo("user-service", "user-a:8088")},
+		{memberInfo: mkMemberInfo("user-service", "user-b:8088")},
+	}
+	c.pingMemberFn = func(context.Context, string) error { return errors.New("no route to host") }
+
+	report, err := n.CheckClusterHealth(context.Background(), []string{"user-service"})
+	if err != nil {
+		t.Fatalf("CheckClusterHealth returned error: %v", err)
+	}
+	assertLabelHealth(t, report, "user-service", LabelHealth{Label: "user-service", Total: 2, Live: 0, Dead: 2})
+}
+
+func TestPingNodesKeepsLegacyAllMemberScan(t *testing.T) {
+	c := &cluster{rpcClient: &rpcClient{isClosed: true, pools: map[string]*connPool{}}}
+	c.members = []*Member{
+		{isMaster: true, memberInfo: &clusterpb.MemberInfo{Label: "master", ServiceAddr: "master:8088"}},
+		{memberInfo: mkMemberInfo("user-service", "user-dead:8088")},
+		{memberInfo: mkMemberInfo("chat-service", "chat-dead:8088")},
+	}
+
+	lives, dies, err := c.pingNodes([]string{"missing-service"})
+	if err != nil {
+		t.Fatalf("pingNodes returned error: %v", err)
+	}
+	if len(lives) != 0 {
+		t.Fatalf("lives = %v, want none", lives)
+	}
+	if !reflect.DeepEqual(dies, []string{"missing-service"}) {
+		t.Fatalf("dies = %v, want only missing requested label because legacy pool failures are skipped", dies)
+	}
+}
+
+func assertLabelHealth(t *testing.T, report *HealthReport, label string, want LabelHealth) {
+	t.Helper()
+	for _, got := range report.Labels {
+		if got.Label == label {
+			if got != want {
+				t.Fatalf("label %q health = %+v, want %+v", label, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("label %q not found in report %+v", label, report.Labels)
+}
+
+func assertMemberHealth(t *testing.T, report *HealthReport, addr string, alive bool) {
+	t.Helper()
+	for _, got := range report.Members {
+		if got.ServiceAddr == addr {
+			if got.Alive != alive {
+				t.Fatalf("member %q alive = %v, want %v", addr, got.Alive, alive)
+			}
+			if !alive && got.Error == "" {
+				t.Fatalf("dead member %q has empty error detail", addr)
+			}
+			return
+		}
+	}
+	t.Fatalf("member %q not found in report %+v", addr, report.Members)
+}

--- a/cluster/member_side_effect_test.go
+++ b/cluster/member_side_effect_test.go
@@ -1,0 +1,46 @@
+package cluster
+
+import "testing"
+
+func TestDelayedRemoveSideEffectDoesNotDeleteNewerReAdd(t *testing.T) {
+	n := newTestNode()
+	info := memberInfo("svc:8088", "Svc")
+	if !n.cluster.addMember(info, 5, 10) {
+		t.Fatal("initial addMember was not applied")
+	}
+	if !n.cluster.delMember(info.ServiceAddr, 6, 10) {
+		t.Fatal("delMember was not applied")
+	}
+	if !n.cluster.addMember(info, 7, 10) {
+		t.Fatal("newer re-add was not applied")
+	}
+	n.addRemoteMemberIfCurrent(info)
+
+	// Simulate the old DelMember goroutine resuming after the newer re-add route
+	// was already published. It must not tear down the live member's route/pool.
+	n.removeRemoteMemberIfAbsent(info.ServiceAddr)
+
+	members := n.handler.findMembers("Svc")
+	if len(members) != 1 || members[0].ServiceAddr != info.ServiceAddr {
+		t.Fatalf("members after delayed remove side effect = %v, want live re-add", members)
+	}
+}
+
+func TestDelayedAddSideEffectDoesNotPublishRemovedMember(t *testing.T) {
+	n := newTestNode()
+	info := memberInfo("svc:8088", "Svc")
+	if !n.cluster.addMember(info, 5, 10) {
+		t.Fatal("addMember was not applied")
+	}
+	if !n.cluster.delMember(info.ServiceAddr, 6, 10) {
+		t.Fatal("delMember was not applied")
+	}
+
+	// Simulate an older NewMember/heartbeat side effect resuming after a newer
+	// remove already won the membership state.
+	n.addRemoteMemberIfCurrent(info)
+
+	if members := n.handler.findMembers("Svc"); len(members) != 0 {
+		t.Fatalf("members after delayed add side effect = %v, want none", members)
+	}
+}

--- a/cluster/member_snapshot.go
+++ b/cluster/member_snapshot.go
@@ -1,0 +1,67 @@
+package cluster
+
+import (
+	"time"
+
+	"github.com/lonng/nano/cluster/clusterpb"
+)
+
+type memberSnapshot struct {
+	isMaster          bool
+	label             string
+	serviceAddr       string
+	lastHeartbeatAt   time.Time
+	memberInfo        *clusterpb.MemberInfo
+	membershipEpoch   uint64
+	membershipVersion uint64
+}
+
+func (c *cluster) memberSnapshots() []memberSnapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.memberSnapshotsLocked()
+}
+
+func (c *cluster) memberSnapshotsLocked() []memberSnapshot {
+	snapshot := make([]memberSnapshot, 0, len(c.members))
+	for _, m := range c.members {
+		if m == nil {
+			continue
+		}
+		info := cloneMemberInfo(m.memberInfo)
+		s := memberSnapshot{
+			isMaster:          m.isMaster,
+			lastHeartbeatAt:   m.lastHeartbeatAt,
+			memberInfo:        info,
+			membershipEpoch:   m.membershipEpoch,
+			membershipVersion: m.membershipVersion,
+		}
+		if info != nil {
+			s.label = info.Label
+			s.serviceAddr = info.ServiceAddr
+		}
+		snapshot = append(snapshot, s)
+	}
+	return snapshot
+}
+
+func cloneMemberInfo(info *clusterpb.MemberInfo) *clusterpb.MemberInfo {
+	if info == nil {
+		return nil
+	}
+	clone := *info
+	if len(info.Services) != 0 {
+		clone.Services = append([]string(nil), info.Services...)
+	}
+	return &clone
+}
+
+func (s memberSnapshot) member() Member {
+	return Member{
+		isMaster:          s.isMaster,
+		memberInfo:        cloneMemberInfo(s.memberInfo),
+		lastHeartbeatAt:   s.lastHeartbeatAt,
+		membershipEpoch:   s.membershipEpoch,
+		membershipVersion: s.membershipVersion,
+	}
+}

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -124,8 +124,19 @@ type Node struct {
 	// per-IP cap (H11). Accessed atomically.
 	acceptedConns int64
 
-	once          sync.Once
-	keepaliveExit chan struct{}
+	once              sync.Once
+	keepaliveExit     chan struct{}
+	keepaliveStopOnce sync.Once
+	drainMu           sync.Mutex
+	heartbeatGuard    chan struct{}
+
+	initialized          atomic.Bool
+	clusterListening     atomic.Bool
+	clientListening      atomic.Bool
+	registeredWithMaster atomic.Bool
+	draining             atomic.Bool
+	drained              atomic.Bool
+	shutdown             atomic.Bool
 
 	// HTTP server
 	httpServer *http.Server
@@ -141,6 +152,7 @@ func (n *Node) Startup() error {
 	if n.ServiceAddr == "" {
 		return errors.New("service address cannot be empty in master node")
 	}
+	n.resetRolloutState()
 	n.sessions = map[int64]*session.Session{}
 	n.connectionCount = map[string]uint{}
 	n.cluster = newCluster(n)
@@ -184,6 +196,7 @@ func (n *Node) Startup() error {
 	if n.ClientAddr != "" {
 		log.Println(fmt.Sprintf("Listen and serve on %s", n.ClientAddr))
 		if err := n.listenAndServe(); err != nil {
+			n.cleanupFailedStartup()
 			return err
 		}
 	}
@@ -193,9 +206,12 @@ func (n *Node) Startup() error {
 	// endpoint is never routed through the public client listener.
 	if n.OpenPrometheus {
 		if err := n.startPrometheus(); err != nil {
+			n.cleanupFailedStartup()
 			return err
 		}
 	}
+
+	n.initialized.Store(true)
 
 	return nil
 }
@@ -232,6 +248,7 @@ func (n *Node) listenAndServe() error {
 		return err
 	}
 	n.clientServer = server
+	n.clientListening.Store(true)
 
 	// Honor the configured TLS material so WithTSLConfig actually serves
 	// HTTPS/WSS instead of being silently ignored (M30). The serve loop runs in
@@ -903,6 +920,7 @@ func (n *Node) initNode() error {
 	clusterpb.RegisterMemberServer(n.server, n)
 
 	go n.runGRPCServer(listener)
+	n.clusterListening.Store(true)
 
 	n.cluster.setRpcClient(n.rpcClient)
 	if n.IsMaster {
@@ -916,6 +934,7 @@ func (n *Node) initNode() error {
 			},
 		}
 		n.cluster.addLocalMember(member)
+		n.registeredWithMaster.Store(true)
 	} else {
 		pool, err := n.rpcClient.getConnPool(n.AdvertiseAddr)
 		if err != nil {
@@ -939,6 +958,7 @@ func (n *Node) initNode() error {
 			if err == nil {
 				n.handler.initRemoteService(resp.Members)
 				n.cluster.initMembers(resp.Members, resp.GetMembershipVersion(), resp.GetMembershipEpoch())
+				n.registeredWithMaster.Store(true)
 				break
 			}
 			log.Println("Register current node to cluster failed", err, "and will retry in", n.RetryInterval.String())
@@ -967,37 +987,18 @@ func (n *Node) Shutdown() {
 		components[i].Comp.Shutdown()
 	}
 
-	// Close sendHeartbeat
-	if n.keepaliveExit != nil {
-		close(n.keepaliveExit)
-	}
+	n.shutdown.Store(true)
 	// Stop the master heartbeat-checker goroutine so it no longer mutates stale
 	// cluster state after shutdown (M13). Idempotent / no-op when not started.
 	if n.cluster != nil {
 		n.cluster.stopHeartbeatChecker()
 	}
-	if !n.IsMaster && n.AdvertiseAddr != "" {
-		pool, err := n.rpcClient.getConnPool(n.AdvertiseAddr)
-		if err != nil {
-			log.Println("Retrieve master address error", err)
-			goto EXIT
-		}
-		client := clusterpb.NewMasterClient(pool.Get())
-		request := &clusterpb.UnregisterRequest{
-			ServiceAddr: n.ServiceAddr,
-		}
-		// Bound shutdown unregister so a stalled master cannot hang shutdown
-		// indefinitely (H23).
-		ctx, cancel := context.WithTimeout(context.Background(), remoteRPCTimeout)
-		_, err = client.Unregister(ctx, request)
-		cancel()
-		if err != nil {
-			log.Println("Unregister current node failed", err)
-			goto EXIT
-		}
+	ctx, cancel := context.WithTimeout(context.Background(), remoteRPCTimeout)
+	if err := n.Drain(ctx); err != nil {
+		log.Println("Drain current node failed", err)
 	}
+	cancel()
 
-EXIT:
 	if n.server != nil {
 		n.server.GracefulStop()
 	}
@@ -1032,6 +1033,9 @@ EXIT:
 	if n.rpcClient != nil {
 		n.rpcClient.closePool()
 	}
+	n.initialized.Store(false)
+	n.clusterListening.Store(false)
+	n.clientListening.Store(false)
 }
 
 func (n *Node) storeSession(s *session.Session) {
@@ -1258,8 +1262,7 @@ func (n *Node) NewMember(_ context.Context, req *clusterpb.NewMemberRequest) (*c
 		return nil, ErrInvalidRegisterReq
 	}
 	if n.cluster.addMember(req.MemberInfo, req.GetMembershipVersion(), req.GetMembershipEpoch()) {
-		n.handler.delMember(req.MemberInfo.GetServiceAddr())
-		n.handler.addRemoteService(req.MemberInfo)
+		n.addRemoteMemberIfCurrent(req.MemberInfo)
 	}
 	return &clusterpb.NewMemberResponse{}, nil
 }
@@ -1270,9 +1273,32 @@ func (n *Node) DelMember(_ context.Context, req *clusterpb.DelMemberRequest) (*c
 	}
 	log.Println("[Node] DelMember member", req.String())
 	if n.cluster.delMember(req.ServiceAddr, req.GetMembershipVersion(), req.GetMembershipEpoch()) {
-		n.removeRemoteMember(req.ServiceAddr)
+		n.removeRemoteMemberIfAbsent(req.ServiceAddr)
 	}
 	return &clusterpb.DelMemberResponse{}, nil
+}
+
+func (n *Node) addRemoteMemberIfCurrent(info *clusterpb.MemberInfo) {
+	if n == nil || info == nil || info.ServiceAddr == "" {
+		return
+	}
+	if n.cluster != nil && !n.cluster.isKnownAddr(info.ServiceAddr) {
+		return
+	}
+	if n.handler != nil {
+		n.handler.delMember(info.ServiceAddr)
+		n.handler.addRemoteService(info)
+	}
+}
+
+func (n *Node) removeRemoteMemberIfAbsent(addr string) {
+	if n == nil || addr == "" {
+		return
+	}
+	if n.cluster != nil && n.cluster.isKnownAddr(addr) {
+		return
+	}
+	n.removeRemoteMember(addr)
 }
 
 // removeRemoteMember applies all local cleanup for a remote member leaving the
@@ -1373,6 +1399,17 @@ func (n *Node) keepalive() {
 		return
 	}
 	heartbeat := func() {
+		if n.draining.Load() {
+			return
+		}
+		releaseHeartbeat, ok := n.tryAcquireHeartbeatGuard()
+		if !ok {
+			return
+		}
+		defer releaseHeartbeat()
+		if n.draining.Load() {
+			return
+		}
 		pool, err := n.rpcClient.getConnPool(n.AdvertiseAddr)
 		if err != nil {
 			log.Println("rpcClient master conn", err)
@@ -1405,7 +1442,7 @@ func (n *Node) keepalive() {
 		}
 		if len(resp.GetMembers()) == 0 && len(resp.GetRemovedMembers()) == 0 && !resp.GetResetMembership() {
 			for _, addr := range n.cluster.pruneExpiredStaleEpochMembers(time.Now()) {
-				n.removeRemoteMember(addr)
+				n.removeRemoteMemberIfAbsent(addr)
 			}
 			return
 		}
@@ -1418,14 +1455,13 @@ func (n *Node) keepalive() {
 		// by that member are removed.
 		added, updated, removed := n.cluster.reconcileMembersSnapshot(resp.GetMembers(), resp.GetRemovedMembers(), resp.GetMembershipVersion(), resp.GetMembershipEpoch(), snapshotSeq, resp.GetResetMembership())
 		for _, info := range updated {
-			n.handler.delMember(info.ServiceAddr)
-			n.handler.addRemoteService(info)
+			n.addRemoteMemberIfCurrent(info)
 		}
 		for _, info := range added {
-			n.handler.addRemoteService(info)
+			n.addRemoteMemberIfCurrent(info)
 		}
 		for _, addr := range removed {
-			n.removeRemoteMember(addr)
+			n.removeRemoteMemberIfAbsent(addr)
 		}
 	}
 	go func() {

--- a/cluster/rollout.go
+++ b/cluster/rollout.go
@@ -1,0 +1,201 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lonng/nano/cluster/clusterpb"
+)
+
+// LocalNodeStatus is a local startup and drain signal. It intentionally does not
+// ping peers; callers can combine it with CheckClusterHealth for readiness.
+//
+// A typical readiness predicate is:
+// Initialized && ClusterListening && (!ClientRequired || ClientListening) &&
+// (!RegistrationRequired || Registered) && !Draining && !Shutdown.
+type LocalNodeStatus struct {
+	// Initialized is true only after Startup has completed successfully.
+	Initialized bool
+	// ClusterListening means the local cluster gRPC listener was bound.
+	ClusterListening bool
+	// ClientRequired means ClientAddr is configured for public client traffic.
+	ClientRequired bool
+	// ClientListening means the public client listener was bound.
+	ClientListening bool
+	// RegistrationRequired means this member must register with a remote master.
+	RegistrationRequired bool
+	// Registered means this node is represented in cluster membership: locally
+	// for masters, or by a successful master registration for members.
+	Registered bool
+	// Draining is true after a Drain attempt has started. A drained node should
+	// normally remain not-ready even after Drained becomes true.
+	Draining bool
+	// Drained is true after Drain completed successfully.
+	Drained bool
+	// Shutdown is true after Shutdown started.
+	Shutdown bool
+}
+
+// LocalNodeStatus returns local listener and registration state without probing
+// other cluster members.
+func (n *Node) LocalNodeStatus() LocalNodeStatus {
+	if n == nil {
+		return LocalNodeStatus{}
+	}
+	return LocalNodeStatus{
+		Initialized:          n.initialized.Load(),
+		ClusterListening:     n.clusterListening.Load(),
+		ClientRequired:       n.ClientAddr != "",
+		ClientListening:      n.clientListening.Load(),
+		RegistrationRequired: !n.IsMaster && n.AdvertiseAddr != "",
+		Registered:           n.registeredWithMaster.Load(),
+		Draining:             n.draining.Load(),
+		Drained:              n.drained.Load(),
+		Shutdown:             n.shutdown.Load(),
+	}
+}
+
+// Drain stops this member from refreshing its master registration and unregisters
+// it from the cluster using ctx as the caller-controlled bound. Drain is safe to
+// call before Shutdown and is idempotent after a successful unregister.
+func (n *Node) Drain(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if n == nil {
+		return errors.New("node is nil")
+	}
+
+	n.drainMu.Lock()
+	defer n.drainMu.Unlock()
+	if n.drained.Load() {
+		return nil
+	}
+	n.draining.Store(true)
+	releaseHeartbeat, err := n.acquireHeartbeatGuard(ctx)
+	if err != nil {
+		n.draining.Store(false)
+		return err
+	}
+	defer releaseHeartbeat()
+
+	if n.IsMaster || n.AdvertiseAddr == "" {
+		n.drained.Store(true)
+		return nil
+	}
+	fail := func(err error) error {
+		n.draining.Store(false)
+		return err
+	}
+	if n.rpcClient == nil {
+		return fail(errors.New("rpc client is nil"))
+	}
+
+	pool, err := n.rpcClient.getConnPoolWithContext(ctx, n.AdvertiseAddr)
+	if err != nil {
+		return fail(err)
+	}
+	_, err = clusterpb.NewMasterClient(pool.Get()).Unregister(ctx, &clusterpb.UnregisterRequest{ServiceAddr: n.ServiceAddr})
+	if err != nil {
+		return fail(fmt.Errorf("unregister current node: %w", err))
+	}
+	n.stopKeepalive()
+	n.registeredWithMaster.Store(false)
+	n.drained.Store(true)
+	return nil
+}
+
+func (n *Node) resetRolloutState() {
+	n.once = sync.Once{}
+	n.keepaliveStopOnce = sync.Once{}
+	n.keepaliveExit = nil
+	n.initialized.Store(false)
+	n.clusterListening.Store(false)
+	n.clientListening.Store(false)
+	n.heartbeatGuard = make(chan struct{}, 1)
+	n.registeredWithMaster.Store(false)
+	n.draining.Store(false)
+	n.drained.Store(false)
+	n.shutdown.Store(false)
+}
+
+func (n *Node) stopKeepalive() {
+	if n == nil || n.keepaliveExit == nil {
+		return
+	}
+	n.keepaliveStopOnce.Do(func() { close(n.keepaliveExit) })
+}
+
+func (n *Node) acquireHeartbeatGuard(ctx context.Context) (func(), error) {
+	if ctx == nil {
+		return nil, errors.New("nil context")
+	}
+	ch := n.heartbeatGuardChan()
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (n *Node) tryAcquireHeartbeatGuard() (func(), bool) {
+	ch := n.heartbeatGuardChan()
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, true
+	default:
+		return nil, false
+	}
+}
+
+func (n *Node) heartbeatGuardChan() chan struct{} {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.heartbeatGuard == nil {
+		n.heartbeatGuard = make(chan struct{}, 1)
+	}
+	return n.heartbeatGuard
+}
+
+func (n *Node) cleanupFailedStartup() {
+	ctx, cancel := context.WithTimeout(context.Background(), remoteRPCTimeout)
+	_ = n.Drain(ctx)
+	cancel()
+	if n.cluster != nil {
+		n.cluster.stopHeartbeatChecker()
+	}
+
+	if n.server != nil {
+		n.server.Stop()
+	}
+	if n.httpServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = n.httpServer.Shutdown(ctx)
+		cancel()
+	}
+	if n.clientServer != nil {
+		_ = n.clientServer.Shutdown()
+	}
+	if n.metricsServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = n.metricsServer.Shutdown(ctx)
+		cancel()
+	}
+	if n.rpcClient != nil {
+		n.rpcClient.closePool()
+	}
+	n.initialized.Store(false)
+	n.clusterListening.Store(false)
+	n.clientListening.Store(false)
+	n.registeredWithMaster.Store(false)
+	n.draining.Store(false)
+	n.drained.Store(false)
+	n.shutdown.Store(false)
+}

--- a/cluster/rollout_lifecycle_test.go
+++ b/cluster/rollout_lifecycle_test.go
@@ -1,0 +1,212 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/lonng/nano/cluster/clusterpb"
+	"github.com/lonng/nano/component"
+	"github.com/lonng/nano/internal/log"
+)
+
+func TestLocalNodeStatusReflectsMasterStartup(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	n := &Node{
+		Options:     Options{IsMaster: true, Components: &component.Components{}, ClientAddr: freeAddr(t)},
+		ServiceAddr: freeAddr(t),
+	}
+	if err := n.Startup(); err != nil {
+		t.Fatalf("Startup: %v", err)
+	}
+	t.Cleanup(n.Shutdown)
+
+	got := n.LocalNodeStatus()
+	want := LocalNodeStatus{
+		Initialized:          true,
+		ClusterListening:     true,
+		ClientRequired:       true,
+		ClientListening:      true,
+		RegistrationRequired: false,
+		Registered:           true,
+	}
+	if got != want {
+		t.Fatalf("LocalNodeStatus() = %+v, want %+v", got, want)
+	}
+}
+
+func TestLocalNodeStatusReflectsMemberRegistrationWithoutPeerHealth(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	master := &Node{
+		Options:     Options{IsMaster: true, Components: &component.Components{}},
+		ServiceAddr: freeAddr(t),
+	}
+	if err := master.Startup(); err != nil {
+		t.Fatalf("master Startup: %v", err)
+	}
+	t.Cleanup(master.Shutdown)
+
+	member := &Node{
+		Options: Options{
+			AdvertiseAddr: master.ServiceAddr,
+			RetryInterval: 10 * time.Millisecond,
+			Components:    &component.Components{},
+		},
+		ServiceAddr: freeAddr(t),
+	}
+	if err := member.Startup(); err != nil {
+		t.Fatalf("member Startup: %v", err)
+	}
+	t.Cleanup(member.Shutdown)
+
+	member.cluster.pingMemberFn = func(context.Context, string) error {
+		t.Fatal("LocalNodeStatus must not ping peers")
+		return nil
+	}
+
+	got := member.LocalNodeStatus()
+	if !got.Initialized || !got.ClusterListening || !got.RegistrationRequired || !got.Registered {
+		t.Fatalf("member LocalNodeStatus() = %+v, want initialized cluster listener and master registration", got)
+	}
+	if got.ClientRequired || got.ClientListening {
+		t.Fatalf("member LocalNodeStatus() = %+v, want no client listener requirement", got)
+	}
+}
+
+func TestStartupFailureAfterRegistrationCleansLocalStatus(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	busy, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer busy.Close()
+
+	n := &Node{
+		Options:     Options{IsMaster: true, Components: &component.Components{}, ClientAddr: busy.Addr().String()},
+		ServiceAddr: freeAddr(t),
+	}
+	if err := n.Startup(); err == nil {
+		n.Shutdown()
+		t.Fatal("expected Startup to fail when client listener is already bound")
+	}
+
+	got := n.LocalNodeStatus()
+	if got.Initialized || got.ClusterListening || got.ClientListening || got.Registered || got.Draining || got.Drained || got.Shutdown {
+		t.Fatalf("LocalNodeStatus after failed Startup = %+v, want no ready/drain/shutdown proof", got)
+	}
+	if n.cluster == nil || n.cluster.heartbeatDone == nil {
+		t.Fatal("failed master startup did not initialize heartbeat checker state")
+	}
+	select {
+	case <-n.cluster.heartbeatDone:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat checker still running after failed master Startup cleanup")
+	}
+}
+
+func TestDrainReturnsCanceledContextWithoutDialing(t *testing.T) {
+	n := newTestNode()
+	n.ServiceAddr = "member:8088"
+	n.AdvertiseAddr = "master:8088"
+	n.rpcClient = newRPCClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := n.Drain(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Drain canceled context error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDrainFailureKeepsNodeRetryable(t *testing.T) {
+	n := newTestNode()
+	n.ServiceAddr = "member:8088"
+	n.AdvertiseAddr = "master:8088"
+	n.rpcClient = newRPCClient()
+	n.rpcClient.closePool()
+	n.keepaliveExit = make(chan struct{})
+
+	if err := n.Drain(context.Background()); err == nil {
+		t.Fatal("Drain returned nil with a closed rpc client, want error")
+	}
+	got := n.LocalNodeStatus()
+	if got.Draining {
+		t.Fatalf("LocalNodeStatus after failed Drain = %+v, want draining cleared for retry", got)
+	}
+	if n.drained.Load() {
+		t.Fatal("failed Drain marked node drained")
+	}
+	select {
+	case <-n.keepaliveExit:
+		t.Fatal("failed Drain stopped keepalive; node cannot recover without restart")
+	default:
+	}
+}
+
+func TestDrainWaitsForInFlightHeartbeatBeforeUnregister(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	master := &Node{
+		Options:     Options{IsMaster: true, Components: &component.Components{}},
+		ServiceAddr: freeAddr(t),
+	}
+	if err := master.Startup(); err != nil {
+		t.Fatalf("master Startup: %v", err)
+	}
+	t.Cleanup(master.Shutdown)
+
+	member := &Node{
+		Options: Options{
+			AdvertiseAddr: master.ServiceAddr,
+			RetryInterval: 10 * time.Millisecond,
+			Components:    &component.Components{},
+		},
+		ServiceAddr: freeAddr(t),
+	}
+	if err := member.Startup(); err != nil {
+		t.Fatalf("member Startup: %v", err)
+	}
+	t.Cleanup(member.Shutdown)
+
+	releaseHeartbeat, err := member.acquireHeartbeatGuard(context.Background())
+	if err != nil {
+		t.Fatalf("acquireHeartbeatGuard: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- member.Drain(context.Background()) }()
+	select {
+	case err := <-done:
+		releaseHeartbeat()
+		t.Fatalf("Drain returned while heartbeat was in-flight: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseHeartbeat()
+	if err := <-done; err != nil {
+		t.Fatalf("Drain after heartbeat release returned error: %v", err)
+	}
+	if master.cluster.isKnownAddr(member.ServiceAddr) {
+		t.Fatalf("master still knows drained member %s", member.ServiceAddr)
+	}
+	if got := member.LocalNodeStatus(); !got.Draining || !got.Drained {
+		t.Fatalf("LocalNodeStatus after successful Drain = %+v, want draining and drained", got)
+	}
+}
+
+func TestUnregisterAlreadyRemovedMemberIsIdempotent(t *testing.T) {
+	log.SetLogger(&noopLogger{})
+	c, _ := newMasterCluster(t)
+	c.addMember(memberInfo("127.0.0.1:9002", "svc"), 0, 0)
+
+	req := &clusterpb.UnregisterRequest{ServiceAddr: "127.0.0.1:9002"}
+	if _, err := c.Unregister(context.Background(), req); err != nil {
+		t.Fatalf("first Unregister returned error: %v", err)
+	}
+	if _, err := c.Unregister(context.Background(), req); err != nil {
+		t.Fatalf("second Unregister returned error: %v, want idempotent success", err)
+	}
+	if c.isKnownAddr(req.ServiceAddr) {
+		t.Fatalf("member %s still exists after idempotent unregister", req.ServiceAddr)
+	}
+}

--- a/cluster/ws.go
+++ b/cluster/ws.go
@@ -21,7 +21,6 @@
 package cluster
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -33,13 +32,25 @@ import (
 	"github.com/lonng/nano/internal/log"
 )
 
+type websocketConn interface {
+	NextReader() (int, io.Reader, error)
+	WriteMessage(int, []byte) error
+	WriteControl(int, []byte, time.Time) error
+	Close() error
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+}
+
 // wsConn is an adapter to t.Conn, which implements all t.Conn
 // interface base on *websocket.Conn
 type wsConn struct {
-	conn   *websocket.Conn
+	conn   websocketConn
 	typ    int // message type
 	reader io.Reader
-	mu     sync.Mutex //
+	mu     sync.Mutex
+	closed bool
 }
 
 // newWSConn return an initialized *wsConn
@@ -66,6 +77,9 @@ func newWSConn(conn *websocket.Conn) (*wsConn, error) {
 
 // RemoveIpAddress the address of the client that connected to the server
 func (c *wsConn) RemoveIpAddress() string {
+	if c == nil || c.conn == nil {
+		return ""
+	}
 	return c.conn.RemoteAddr().String()
 }
 
@@ -73,6 +87,9 @@ func (c *wsConn) RemoveIpAddress() string {
 // Read can be made to time out and return an Error with Timeout() == true
 // after a fixed time limit; see SetDeadline and SetReadDeadline.
 func (c *wsConn) Read(b []byte) (int, error) {
+	if c == nil || c.conn == nil || c.reader == nil {
+		return 0, ErrBrokenPipe
+	}
 	n, err := c.reader.Read(b)
 	if err != nil && err != io.EOF {
 		return n, err
@@ -91,13 +108,15 @@ func (c *wsConn) Read(b []byte) (int, error) {
 // Write can be made to time out and return an Error with Timeout() == true
 // after a fixed time limit; see SetDeadline and SetWriteDeadline.
 func (c *wsConn) Write(b []byte) (int, error) {
-	if c == nil || c.conn == nil {
-		log.Error("wsConn or its underlying connection is nil")
-		return 0, errors.New("wsConn or its underlying connection is nil")
+	if c == nil {
+		return 0, ErrBrokenPipe
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.closed || c.conn == nil {
+		return 0, ErrBrokenPipe
+	}
 
 	log.Debug(fmt.Sprintf("Writing %d bytes to WebSocket connection", len(b)))
 	err := c.conn.WriteMessage(websocket.BinaryMessage, b)
@@ -111,28 +130,42 @@ func (c *wsConn) Write(b []byte) (int, error) {
 // Close closes the connection.
 // Any blocked Read or Write operations will be unblocked and return errors.
 func (c *wsConn) Close() error {
+	if c == nil {
+		return ErrBrokenPipe
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	if c.conn == nil {
+		c.closed = true
+		return ErrBrokenPipe
+	}
 	// Send a close control frame so clients/proxies observe a normal closure
 	// instead of an abnormal one on every server-side close (L4). Best-effort:
 	// proceed to close the underlying connection regardless. The write mutex
 	// serializes this against concurrent Write calls.
-	c.mu.Lock()
 	_ = c.conn.WriteControl(
 		websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 		time.Now().Add(time.Second),
 	)
-	c.mu.Unlock()
+	c.closed = true
 	return c.conn.Close()
 }
 
 // LocalAddr returns the local network address.
 func (c *wsConn) LocalAddr() net.Addr {
+	if c == nil || c.conn == nil {
+		return nil
+	}
 	return c.conn.LocalAddr()
 }
 
 // RemoteAddr returns the remote network address.
 func (c *wsConn) RemoteAddr() net.Addr {
-	if c.conn == nil {
+	if c == nil || c.conn == nil {
 		log.Error("RemoteAddr: conn is nil")
 		return nil
 	}
@@ -155,6 +188,9 @@ func (c *wsConn) RemoteAddr() net.Addr {
 //
 // A zero value for t means I/O operations will not time out.
 func (c *wsConn) SetDeadline(t time.Time) error {
+	if c == nil || c.conn == nil {
+		return ErrBrokenPipe
+	}
 	if err := c.conn.SetReadDeadline(t); err != nil {
 		return err
 	}
@@ -166,6 +202,9 @@ func (c *wsConn) SetDeadline(t time.Time) error {
 // and any currently-blocked Read call.
 // A zero value for t means Read will not time out.
 func (c *wsConn) SetReadDeadline(t time.Time) error {
+	if c == nil || c.conn == nil {
+		return ErrBrokenPipe
+	}
 	return c.conn.SetReadDeadline(t)
 }
 
@@ -175,5 +214,8 @@ func (c *wsConn) SetReadDeadline(t time.Time) error {
 // some of the data was successfully written.
 // A zero value for t means Write will not time out.
 func (c *wsConn) SetWriteDeadline(t time.Time) error {
+	if c == nil || c.conn == nil {
+		return ErrBrokenPipe
+	}
 	return c.conn.SetWriteDeadline(t)
 }

--- a/cluster/ws_test.go
+++ b/cluster/ws_test.go
@@ -1,0 +1,135 @@
+package cluster
+
+import (
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fasthttp/websocket"
+)
+
+func TestWSConnCloseNilSafe(t *testing.T) {
+	tests := []struct {
+		name string
+		conn *wsConn
+	}{
+		{name: "nil receiver"},
+		{name: "nil underlying websocket", conn: &wsConn{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.conn.Close(); err != ErrBrokenPipe {
+				t.Fatalf("Close() error = %v, want %v", err, ErrBrokenPipe)
+			}
+		})
+	}
+}
+
+func TestWSConnCloseIsIdempotent(t *testing.T) {
+	fake := &fakeWebsocketConn{}
+	conn := &wsConn{conn: fake}
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("first Close() error = %v, want nil", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("second Close() error = %v, want nil", err)
+	}
+	if fake.closeCalls != 1 {
+		t.Fatalf("underlying Close calls = %d, want 1", fake.closeCalls)
+	}
+	if fake.writeControlCalls != 1 {
+		t.Fatalf("WriteControl calls = %d, want 1", fake.writeControlCalls)
+	}
+}
+
+func TestWSConnCloseAttemptsUnderlyingCloseWhenCloseFrameFails(t *testing.T) {
+	closeErr := errors.New("close failed")
+	fake := &fakeWebsocketConn{writeControlErr: errors.New("control failed"), closeErr: closeErr}
+	conn := &wsConn{conn: fake}
+
+	if err := conn.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("Close() error = %v, want %v", err, closeErr)
+	}
+	if fake.closeCalls != 1 {
+		t.Fatalf("underlying Close calls = %d, want 1", fake.closeCalls)
+	}
+}
+
+func TestWSConnCloseConcurrentWithWriteDoesNotPanic(t *testing.T) {
+	fake := &fakeWebsocketConn{}
+	conn := &wsConn{conn: fake}
+
+	const goroutines = 64
+	panicCh := make(chan interface{}, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			defer func() { panicCh <- recover() }()
+			if i%2 == 0 {
+				_ = conn.Close()
+				return
+			}
+			_, _ = conn.Write([]byte("x"))
+		}(i)
+	}
+	wg.Wait()
+	close(panicCh)
+
+	for p := range panicCh {
+		if p != nil {
+			t.Fatalf("Close/Write panicked: %v", p)
+		}
+	}
+}
+
+type fakeWebsocketConn struct {
+	mu                sync.Mutex
+	closed            bool
+	closeCalls        int
+	writeCalls        int
+	writeControlCalls int
+	writeControlErr   error
+	closeErr          error
+}
+
+func (f *fakeWebsocketConn) NextReader() (int, io.Reader, error) {
+	return websocket.BinaryMessage, strings.NewReader(""), nil
+}
+
+func (f *fakeWebsocketConn) WriteMessage(int, []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return ErrBrokenPipe
+	}
+	f.writeCalls++
+	return nil
+}
+
+func (f *fakeWebsocketConn) WriteControl(int, []byte, time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writeControlCalls++
+	return f.writeControlErr
+}
+
+func (f *fakeWebsocketConn) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCalls++
+	f.closed = true
+	return f.closeErr
+}
+
+func (f *fakeWebsocketConn) LocalAddr() net.Addr  { return ipAddr{s: "local:1"} }
+func (f *fakeWebsocketConn) RemoteAddr() net.Addr { return ipAddr{s: "remote:1"} }
+
+func (f *fakeWebsocketConn) SetReadDeadline(time.Time) error  { return nil }
+func (f *fakeWebsocketConn) SetWriteDeadline(time.Time) error { return nil }

--- a/interface.go
+++ b/interface.go
@@ -21,6 +21,7 @@
 package nano
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -152,4 +153,36 @@ func PingNodes(nodeLabels []string) (lives []string, dies []string, err error) {
 		return nil, nil, fmt.Errorf("Node is not initialized")
 	}
 	return node.PingNodes(nodeLabels)
+}
+
+// CheckClusterHealth probes cluster members matching nodeLabels and returns
+// label-level and member-level health details. Unlike PingNodes, requested
+// labels are filtered before dialing so stale unrelated members do not affect
+// readiness checks.
+func CheckClusterHealth(ctx context.Context, nodeLabels []string) (*cluster.HealthReport, error) {
+	node := runtime.CurrentNode()
+	if node == nil {
+		return nil, fmt.Errorf("Node is not initialized")
+	}
+	return node.CheckClusterHealth(ctx, nodeLabels)
+}
+
+// LocalNodeStatus returns local startup/registration state without pinging
+// cluster peers.
+func LocalNodeStatus() (cluster.LocalNodeStatus, error) {
+	node := runtime.CurrentNode()
+	if node == nil {
+		return cluster.LocalNodeStatus{}, fmt.Errorf("Node is not initialized")
+	}
+	return node.LocalNodeStatus(), nil
+}
+
+// Drain unregisters the current member from the cluster using ctx as the caller
+// controlled bound. It is safe to call before Shutdown.
+func Drain(ctx context.Context) error {
+	node := runtime.CurrentNode()
+	if node == nil {
+		return fmt.Errorf("Node is not initialized")
+	}
+	return node.Drain(ctx)
 }


### PR DESCRIPTION
## Summary
- Add rollout-safe health primitives: `CheckClusterHealth(ctx, labels)`, `LocalNodeStatus()`, and `Drain(ctx)`.
- Preserve legacy `PingNodes` behavior while exposing per-label and per-member health detail for Kubernetes readiness policies.
- Harden rollout races around heartbeat/drain, membership snapshots, delayed side effects, stale conn pools, and websocket close.

## Verification
- `go test ./...`

Fixes #14